### PR TITLE
[ONPREM-1221] Add the fake task agent for acceptance tests & publish images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,24 +6,25 @@ orbs:
 workflows:
   main-workflow:
     jobs:
-      - download-taskagent:
+      - prepare-agents:
           context: org-global
-      - scan-image:
-          context: org-global
-          requires:
-            - download-taskagent
-      - build-and-publish-image:
+      # These are scratch images with a single binary (this is scanned on creation by execution) so I think we can do without scanning?
+      # - scan-image:
+      #     context: org-global
+      #     requires:
+      #       - prepare-agents
+      - build-and-publish-images:
           name: build-and-publish-image-amd64
           context: org-global
           requires:
-            - scan-image
-      - build-and-publish-image:
+            - prepare-agents
+      - build-and-publish-images:
           name: build-and-publish-image-arm64
           resource: arm.medium
           arch: arm64
           context: org-global
           requires:
-            - scan-image
+            - prepare-agents
 
 executors:
   ccc:
@@ -43,22 +44,22 @@ parameters:
     default: "runner-init"
 
 jobs:
-  download-taskagent:
+  prepare-agents:
     machine:
       image: ubuntu-2204:2024.02.7
-      resource_class: small
+      resource_class: large
     steps:
       - checkout
       - docker_login
-      - run: ./do download-taskagent amd64
-      - run: ./do download-taskagent arm64
+      - run: ./do build-fake-agents
+      - run: ./do download-taskagents
       - persist_to_workspace:
           root: .
           paths:
-            - "./circleci-agent-*"
+            - "./bin/circleci-*"
       - notify_failing_main
 
-  build-and-publish-image:
+  build-and-publish-images:
     parameters:
       resource:
         type: string
@@ -74,7 +75,7 @@ jobs:
       - attach_workspace:
           at: .
       - docker_login
-      - run: docker build -t circleci/<< pipeline.parameters.release-name >>:agent-<< parameters.arch >> --build-arg ARCH=<< parameters.arch >> .
+      - run: ./do build-docker-images << pipeline.parameters.release-name >> << parameters.arch >>
       # TODO: Publish images (on main) once the repo is set up
       - notify_failing_main
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,11 +8,6 @@ workflows:
     jobs:
       - prepare-agents:
           context: org-global
-      # These are scratch images with a single binary (this is scanned on creation by execution) so I think we can do without scanning?
-      # - scan-image:
-      #     context: org-global
-      #     requires:
-      #       - prepare-agents
       - build-and-publish-images:
           name: build-and-publish-image-amd64
           context: org-global
@@ -25,18 +20,15 @@ workflows:
           context: org-global
           requires:
             - prepare-agents
-
-executors:
-  ccc:
-    docker:
-      - image: circleci/command-convenience:0.1
-        auth:
-          username: $DOCKER_HUB_USER
-          password: $DOCKER_HUB_PASSWORD
-    environment:
-      NAME: << pipeline.parameters.release-name >>
-      DOCKERFILE_PATH: Dockerfile
-      TEAM: on-prem
+      - publish-manifest:
+          context: org-global
+          filters:
+            branches:
+              only:
+                - main
+          requires:
+            - build-and-publish-image-amd64
+            - build-and-publish-image-arm64
 
 parameters:
   release-name:
@@ -76,21 +68,21 @@ jobs:
           at: .
       - docker_login
       - run: ./do build-docker-images << pipeline.parameters.release-name >> << parameters.arch >>
-      # TODO: Publish images (on main) once the repo is set up
+      - when:
+          condition:
+            equal: [ main, << pipeline.git.branch >> ]
+          steps:
+            - run: ./do publish-docker-images << pipeline.parameters.release-name >> << parameters.arch >>
       - notify_failing_main
 
-  scan-image:
-    executor: ccc
+  publish-manifest:
+    machine:
+      image: ubuntu-2204:2024.02.7
+      resource_class: small
     steps:
       - checkout
-      - setup_remote_docker
-      - attach_workspace:
-          at: .
-      - run:
-          name: Scan Docker images
-          command: scan
-      - store_artifacts:
-          path: ccc-image-scan-results
+      - docker_login
+      - run: ./do publish-docker-manifest << pipeline.parameters.release-name >>
       - notify_failing_main
 
 commands:

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,25 @@
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+coverage.txt
+/test-reports
+
+# Test binary, build with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# file system and ide files
+.DS_Store
+/.idea
+/*.iml
+/bin
+/target
+
+secrets
+pkg_test.go
+api/docs/*.html

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
 # Runner Init
 
-An image for bootstrapping container runner tasks
+This repo contains code and images responsible for bootstrapping Runner docker tasks. At present there are two components:
+
+- The runner init image definition
+- A fake task agent used in Kubernetes acceptance testing

--- a/do
+++ b/do
@@ -33,6 +33,36 @@ build-docker-images() {
     docker build -t circleci/"$repo":test-agent-"$arch" --build-arg ARCH="$arch" -f ./runner-init/fake-agent.Dockerfile .
 }
 
+# This variable is used, but shellcheck can't tell.
+# shellcheck disable=SC2034
+help_publish_docker_images="Publish the runner init images"
+publish-docker-images() {
+    repo=${1:?'image repo name must be specified'}
+    arch=${2:?'image arch must be specified'}
+
+    docker push circleci/"$repo":agent-"$arch"
+    docker push circleci/"$repo":test-agent-"$arch"
+}
+
+# This variable is used, but shellcheck can't tell.
+# shellcheck disable=SC2034
+help_publish_docker_manifest="Publish the mutliarch manifest"
+publish-docker-manifest() {
+    repo=${1:?'image repo name must be specified'}
+
+    docker manifest create circleci/runner-init:agent \
+        --amend circleci/runner-init:agent-amd64 \
+        --amend circleci/runner-init:agent-arm64
+
+    docker manifest push circleci/runner-init:agent
+
+    docker manifest create circleci/runner-init:test-agent \
+        --amend circleci/runner-init:test-agent-amd64 \
+        --amend circleci/runner-init:test-agent-arm64
+
+    docker manifest push circleci/runner-init:test-agent
+}
+
 help-text-intro() {
     echo "
 DO

--- a/do
+++ b/do
@@ -4,7 +4,7 @@ set -eu -o pipefail
 
 # This variable is used, but shellcheck can't tell.
 # shellcheck disable=SC2034
-help_download_taskagent="Download task agents via the picard image"
+help_download_taskagents="Download task agents via the picard image"
 download-taskagents() {
     id=$(docker create circleci/picard:agent)
 

--- a/do
+++ b/do
@@ -4,13 +4,33 @@ set -eu -o pipefail
 
 # This variable is used, but shellcheck can't tell.
 # shellcheck disable=SC2034
-help_download_taskagent="Download task agent via the picard image"
-download-taskagent() {
-    arch=${1:?'task agent arch must be specified'}
-
+help_download_taskagent="Download task agents via the picard image"
+download-taskagents() {
     id=$(docker create circleci/picard:agent)
-    docker cp "$id":/opt/circleci/linux/"$arch"/circleci-agent ./circleci-agent-"$arch"
+
+    docker cp "$id":/opt/circleci/linux/amd64/circleci-agent ./bin/circleci-agent-amd64
+    docker cp "$id":/opt/circleci/linux/arm64/circleci-agent ./bin/circleci-agent-arm64
+
     docker rm -v "$id"
+}
+
+# This variable is used, but shellcheck can't tell.
+# shellcheck disable=SC2034
+help_build_fake_agents="Build the fake agent go binaries"
+build-fake-agents() {
+    GOOS=linux GOARCH=amd64 go build -C ./fake-agent -o ../bin/circleci-fake-agent-amd64 ./
+    GOOS=linux GOARCH=arm64 go build -C ./fake-agent -o ../bin/circleci-fake-agent-arm64 ./
+}
+
+# This variable is used, but shellcheck can't tell.
+# shellcheck disable=SC2034
+help_build_docker_images="Build the runner init images"
+build-docker-images() {
+    repo=${1:?'image repo name must be specified'}
+    arch=${2:?'image arch must be specified'}
+
+    docker build -t circleci/"$repo":agent-"$arch" --build-arg ARCH="$arch" -f ./runner-init/Dockerfile .
+    docker build -t circleci/"$repo":test-agent-"$arch" --build-arg ARCH="$arch" -f ./runner-init/fake-agent.Dockerfile .
 }
 
 help-text-intro() {

--- a/do
+++ b/do
@@ -46,7 +46,7 @@ publish-docker-images() {
 
 # This variable is used, but shellcheck can't tell.
 # shellcheck disable=SC2034
-help_publish_docker_manifest="Publish the mutliarch manifest"
+help_publish_docker_manifest="Publish the multiarch manifest"
 publish-docker-manifest() {
     repo=${1:?'image repo name must be specified'}
 

--- a/fake-agent/go.mod
+++ b/fake-agent/go.mod
@@ -1,0 +1,5 @@
+module github.com/circleci/circleci-fake-agent
+
+go 1.21.0
+
+require github.com/alecthomas/kong v0.9.0

--- a/fake-agent/go.sum
+++ b/fake-agent/go.sum
@@ -1,0 +1,8 @@
+github.com/alecthomas/assert/v2 v2.6.0 h1:o3WJwILtexrEUk3cUVal3oiQY2tfgr/FHWiz/v2n4FU=
+github.com/alecthomas/assert/v2 v2.6.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
+github.com/alecthomas/kong v0.9.0 h1:G5diXxc85KvoV2f0ZRVuMsi45IrBgx9zDNGNj165aPA=
+github.com/alecthomas/kong v0.9.0/go.mod h1:Y47y5gKfHp1hDc7CH7OeXgLIpp+Q2m1Ni0L5s3bI8Os=
+github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=
+github.com/alecthomas/repr v0.4.0/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
+github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
+github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=

--- a/fake-agent/main.go
+++ b/fake-agent/main.go
@@ -81,7 +81,7 @@ func run(opts CommandRequest) {
 			}
 			// Ignore the 413 as a thing. This is just a handy code to pick to trigger us to start misbehaving
 			if resp.StatusCode == http.StatusRequestEntityTooLarge {
-				fmt.Println("fake circleci-agent staring to misbehave")
+				fmt.Println("fake circleci-agent starting to misbehave")
 				launchChildAndMisbehave(opts)
 				panic("shouldn't get here in a test")
 			}

--- a/fake-agent/main.go
+++ b/fake-agent/main.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/alecthomas/kong"
+)
+
+func main() {
+	// Example arguments: _internal agent-runner --verbose --agentAPITaskToken=a84dc93b7900c6ca3e74091785d4a883 --runnerAPIBaseURL=http://127.0.0.1:65244
+
+	opts := CommandRequest{}
+
+	kong.Parse(&opts, kong.Name("circleci-agent"))
+
+	// We need the fake task agent binary to be able to access the local test API from inside the cluster. If we are using kind (or another docker hosted k8s cluster)
+	// for testing then using the domain below will forward requests on to the host machine's localhost interface
+	driver := os.Getenv("DRIVER_MODE")
+	dockerHostAddress := os.Getenv("DOCKER_HOST")
+	if driver == "kubernetes" {
+		url, err := url.Parse(opts.RunnerAPIBaseURL)
+		mustNotError(err)
+		url.Host = fmt.Sprintf("%s:%s", dockerHostAddress, url.Port())
+		opts.RunnerAPIBaseURL = url.String()
+	}
+
+	run(opts)
+}
+
+func run(opts CommandRequest) {
+	fmt.Println("fake circleci-agent 1f3k128h")
+
+	b, err := io.ReadAll(os.Stdin)
+	mustNotError(err)
+	opts.Stdin = string(b)
+
+	b, err = json.Marshal(opts)
+	mustNotError(err)
+	res, err := http.Post(opts.RunnerAPIBaseURL+"/fakes/agent/command", "application/json", bytes.NewReader(b))
+	mustNotError(err)
+	mustNotError(res.Body.Close())
+
+	terminate := make(chan os.Signal, 1)
+	signal.Notify(terminate, syscall.SIGTERM, os.Interrupt)
+
+	shutdownTimer := time.NewTimer(time.Second * 4)
+	for {
+		intervalTimer := time.NewTimer(50 * time.Millisecond)
+		select {
+		case <-shutdownTimer.C:
+			intervalTimer.Stop()
+			fmt.Println("fake circleci-agent shutting down after timeout")
+			return
+		case <-intervalTimer.C:
+			resp, err := http.Get(opts.RunnerAPIBaseURL + "/fakes/agent/terminated")
+			if err != nil {
+				// Exit if the test API has been closed
+				return
+			}
+			mustNotError(resp.Body.Close())
+
+			if resp.StatusCode == http.StatusOK {
+				shutdownTimer.Stop()
+				fmt.Println("fake circleci-agent shutting down at the request of the test harness")
+				resp, err := http.Post(opts.RunnerAPIBaseURL+"/fakes/agent/terminated", "",
+					strings.NewReader(`{"by":"test-api"}`))
+				mustNotError(err)
+				mustNotError(resp.Body.Close())
+				return
+			}
+			// Ignore the 413 as a thing. This is just a handy code to pick to trigger us to start misbehaving
+			if resp.StatusCode == http.StatusRequestEntityTooLarge {
+				fmt.Println("fake circleci-agent staring to misbehave")
+				launchChildAndMisbehave(opts)
+				panic("shouldn't get here in a test")
+			}
+		case <-terminate:
+			intervalTimer.Stop()
+			shutdownTimer.Stop()
+			fmt.Println("fake circleci-agent shutting down after SIGTERM, notifying API")
+			resp, err := http.Post(opts.RunnerAPIBaseURL+"/fakes/agent/terminated", "",
+				strings.NewReader(`{"by":"launch-agent"}`))
+			mustNotError(err)
+			mustNotError(resp.Body.Close())
+			return
+		}
+	}
+}
+
+// Misbehaving mode to test PID group cleanup
+func launchChildAndMisbehave(opts CommandRequest) {
+	signal.Ignore(os.Interrupt)
+
+	cmd := exec.Command("/bin/sleep", "20")
+	err := cmd.Start()
+	mustNotError(err)
+
+	res, err := http.Get(fmt.Sprintf("%s/fakes/agent/pids?taskagent=%d&taskagent-child=%d",
+		opts.RunnerAPIBaseURL, os.Getpid(), cmd.Process.Pid))
+	_ = res.Body.Close()
+	mustNotError(err)
+
+	err = cmd.Wait()
+	mustNotError(err)
+}
+
+func mustNotError(err error) {
+	if err != nil {
+		panic(err)
+	}
+}
+
+type CommandRequest struct {
+	RunnerAPIBaseURL      string        `name:"runnerAPIBaseURL" required:"true"`
+	Allocation            string        `name:"allocation" required:"true"`
+	Verbose               bool          `name:"verbose"`
+	DisableSpinUpStep     bool          `name:"disableSpinUpStep"`
+	DisableIsolatedSSHDir bool          `name:"disableIsolatedSSHDir"`
+	Args                  []string      `arg:""`
+	WorkDir               string        `name:"workDir"`
+	Stdin                 string        `kong:"-"`
+	MaxRunTime            time.Duration `name:"maxRunTime"`
+	PidFile               string        `name:"pidfile"`
+}

--- a/runner-init/Dockerfile
+++ b/runner-init/Dockerfile
@@ -1,0 +1,14 @@
+FROM busybox:stable-musl as build
+
+FROM scratch as temp
+
+ARG ARCH=amd64
+
+COPY ./bin/circleci-agent-${ARCH} /opt/circleci/circleci-agent
+COPY --from=build /bin/cp /bin/cp
+
+FROM scratch
+
+COPY --from=temp / /
+
+ENTRYPOINT ["/bin/cp"]

--- a/runner-init/Dockerfile
+++ b/runner-init/Dockerfile
@@ -1,10 +1,14 @@
 FROM busybox:stable-musl as build
 
-FROM scratch as temp
-
 ARG ARCH=amd64
 
 COPY ./bin/circleci-agent-${ARCH} /opt/circleci/circleci-agent
+RUN ln -s /opt/circleci/circleci-agent /opt/circleci/circleci
+
+FROM scratch as temp
+
+COPY --from=build /opt/circleci/circleci-agent /opt/circleci/circleci-agent
+COPY  --from=build /opt/circleci/circleci /opt/circleci/circleci
 COPY --from=build /bin/cp /bin/cp
 
 FROM scratch

--- a/runner-init/fake-agent.Dockerfile
+++ b/runner-init/fake-agent.Dockerfile
@@ -4,11 +4,11 @@ FROM scratch as temp
 
 ARG ARCH=amd64
 
-COPY ./circleci-agent-${ARCH} /opt/circleci/circleci-agent
+COPY ./bin/circleci-fake-agent-${ARCH} /opt/circleci/circleci-agent
 COPY --from=build /bin/cp /bin/cp
 
 FROM scratch
 
 COPY --from=temp / /
 
-CMD ["/bin/cp"]
+ENTRYPOINT ["/bin/cp"]


### PR DESCRIPTION
Move the code for the fake task agent into this repo & add build/package CI steps for it

Publish agent & test-agent images along with the multi-arch manifest. Add symlinks into the runner init agent image