### PR TITLE
[ONPREM-1222] Create the softlink in the target dir as init image entrypoint

### DIFF
--- a/runner-init/Dockerfile
+++ b/runner-init/Dockerfile
@@ -1,18 +1,8 @@
-FROM busybox:stable-musl as build
+FROM busybox:stable-musl
 
 ARG ARCH=amd64
 
 COPY ./bin/circleci-agent-${ARCH} /opt/circleci/circleci-agent
-RUN ln -s /opt/circleci/circleci-agent /opt/circleci/circleci
+COPY ./runner-init/init.sh /init.sh
 
-FROM scratch as temp
-
-COPY --from=build /opt/circleci/circleci-agent /opt/circleci/circleci-agent
-COPY  --from=build /opt/circleci/circleci /opt/circleci/circleci
-COPY --from=build /bin/cp /bin/cp
-
-FROM scratch
-
-COPY --from=temp / /
-
-ENTRYPOINT ["/bin/cp"]
+ENTRYPOINT ["/init.sh"]

--- a/runner-init/init.sh
+++ b/runner-init/init.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+
+dest=${1:?'task agent dest must be specified'}
+
+cp /opt/circleci/circleci-agent "$dest"/circleci-agent
+ln -s "$dest"/circleci-agent "$dest"/circleci


### PR DESCRIPTION
Add an init script to copy task agent and create the symlink to `circleci`.

I have reverted back to using `busybox` for this as we need a shell to run the init script. This comes at a small cost to image size, but it does mean we don't need to make an `exec` call on task start to make the symlink. In my opinion this tradeoff is worth it, particularly as we are looking to totally remove the `exec` interface from the runner agent