### PR TITLE
[ONPREM-1222] Get server picard versions and build server images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,6 +95,9 @@ jobs:
       - goreleaser_setup
       - docker_login
       - run:
+          name: Checkout server repo
+          command: git clone https://scotty-approver:$SCOTTY_APPROVER_TOKEN@github.com/circleci/server.git
+      - run:
           name: Build and maybe push images
           command: |
             SKIP_PUSH=$(if [ "$CIRCLE_BRANCH" == "main" ]; then echo "false"; else echo "true"; fi) \

--- a/.goreleaser/dockers.yaml
+++ b/.goreleaser/dockers.yaml
@@ -15,6 +15,43 @@ dockers:
     build_flag_templates:
       - "--platform=linux/amd64"
       - "--build-arg=ARCH=amd64"
+      - "--build-arg=PICARD_VERSION=agent"
+    extra_files:
+      - ./target/bin/amd64/orchestrator
+
+  - id: init-amd64-server-4.3
+    image_templates: ["circleci/runner-init:agent-amd64-server-4.3"]
+    skip_push: "{{.Env.SKIP_PUSH}}"
+    dockerfile: ./docker/Dockerfile
+    use: buildx
+    build_flag_templates:
+      - "--platform=linux/amd64"
+      - "--build-arg=ARCH=amd64"
+      - "--build-arg=PICARD_VERSION={{ .Env.SERVER_4_3_PICARD }}"
+    extra_files:
+      - ./target/bin/amd64/orchestrator
+
+  - id: init-amd64-server-4.4
+    image_templates: ["circleci/runner-init:agent-amd64-server-4.4"]
+    skip_push: "{{.Env.SKIP_PUSH}}"
+    dockerfile: ./docker/Dockerfile
+    use: buildx
+    build_flag_templates:
+      - "--platform=linux/amd64"
+      - "--build-arg=ARCH=amd64"
+      - "--build-arg=PICARD_VERSION={{ .Env.SERVER_4_4_PICARD }}"
+    extra_files:
+      - ./target/bin/amd64/orchestrator
+
+  - id: init-amd64-server-4.5
+    image_templates: ["circleci/runner-init:agent-amd64-server-4.5"]
+    skip_push: "{{.Env.SKIP_PUSH}}"
+    dockerfile: ./docker/Dockerfile
+    use: buildx
+    build_flag_templates:
+      - "--platform=linux/amd64"
+      - "--build-arg=ARCH=amd64"
+      - "--build-arg=PICARD_VERSION={{ .Env.SERVER_4_5_PICARD }}"
     extra_files:
       - ./target/bin/amd64/orchestrator
 
@@ -26,8 +63,46 @@ dockers:
     build_flag_templates:
       - "--platform=linux/arm64"
       - "--build-arg=ARCH=arm64"
+      - "--build-arg=PICARD_VERSION=agent"
     extra_files:
       - ./target/bin/arm64/orchestrator
+
+  - id: init-arm64-server-4.3
+    image_templates: ["circleci/runner-init:agent-arm64-server-4.3"]
+    skip_push: "{{.Env.SKIP_PUSH}}"
+    dockerfile: ./docker/Dockerfile
+    use: buildx
+    build_flag_templates:
+      - "--platform=linux/arm64"
+      - "--build-arg=ARCH=arm64"
+      - "--build-arg=PICARD_VERSION={{ .Env.SERVER_4_3_PICARD }}"
+    extra_files:
+      - ./target/bin/arm64/orchestrator
+
+  - id: init-arm64-server-4.4
+    image_templates: ["circleci/runner-init:agent-arm64-server-4.4"]
+    skip_push: "{{.Env.SKIP_PUSH}}"
+    dockerfile: ./docker/Dockerfile
+    use: buildx
+    build_flag_templates:
+      - "--platform=linux/arm64"
+      - "--build-arg=ARCH=arm64"
+      - "--build-arg=PICARD_VERSION={{ .Env.SERVER_4_4_PICARD }}"
+    extra_files:
+      - ./target/bin/arm64/orchestrator
+
+  - id: init-arm64-server-4.5
+    image_templates: ["circleci/runner-init:agent-arm64-server-4.5"]
+    skip_push: "{{.Env.SKIP_PUSH}}"
+    dockerfile: ./docker/Dockerfile
+    use: buildx
+    build_flag_templates:
+      - "--platform=linux/arm64"
+      - "--build-arg=ARCH=arm64"
+      - "--build-arg=PICARD_VERSION={{ .Env.SERVER_4_5_PICARD }}"
+    extra_files:
+      - ./target/bin/arm64/orchestrator
+
 
   - id: testinit-amd64
     image_templates: ["circleci/runner-init:test-agents-amd64"]
@@ -58,6 +133,24 @@ docker_manifests:
     image_templates:
       - "circleci/runner-init:agents-amd64"
       - "circleci/runner-init:agents-arm64"
+    skip_push: "{{.Env.SKIP_PUSH}}"
+
+  - name_template: "circleci/runner-init:agent-server-4.3"
+    image_templates:
+      - "circleci/runner-init:agent-amd64-server-4.3"
+      - "circleci/runner-init:agent-arm64-server-4.3"
+    skip_push: "{{.Env.SKIP_PUSH}}"
+
+  - name_template: "circleci/runner-init:agent-server-4.4"
+    image_templates:
+      - "circleci/runner-init:agent-amd64-server-4.4"
+      - "circleci/runner-init:agent-arm64-server-4.4"
+    skip_push: "{{.Env.SKIP_PUSH}}"
+
+  - name_template: "circleci/runner-init:agent-server-4.5"
+    image_templates:
+      - "circleci/runner-init:agent-amd64-server-4.5"
+      - "circleci/runner-init:agent-arm64-server-4.5"
     skip_push: "{{.Env.SKIP_PUSH}}"
 
   - name_template: "circleci/runner-init:test-agents"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ By following these guidelines, we can easily determine which changes should be i
 
 ## Edge
 
+- [#17](https://github.com/circleci/runner-init/pull/17) [INTERNAL] Build server images.
 - [#16](https://github.com/circleci/runner-init/pull/16) [INTERNAL] Add an acceptance test framework and cases for the init command. In addition, some changes were made to the CLI configuration to account for limitations on positional arguments of the ex test runner.
 - [#14](https://github.com/circleci/runner-init/pull/14) [INTERNAL] Implement the init script as a mode of the orchestrator. This allows for the use of scratch for a minimal base image.
 - [#13](https://github.com/circleci/runner-init/pull/13) [INTERNAL] Use [GoReleaser](https://goreleaser.com/) for building and pushing the images and manifests.

--- a/do
+++ b/do
@@ -29,6 +29,8 @@ help_dev_binary="Build and push the Docker images and manifests"
 images() {
     set -x
 
+    get-server-versions
+
     [[ -f ./bin/goreleaser ]] || install-go-bin "github.com/goreleaser/goreleaser@latest"
 
     SKIP_PUSH="${SKIP_PUSH:-true}" \
@@ -36,7 +38,17 @@ images() {
         ./bin/goreleaser \
         --clean \
         --config "${BUILD_CONFIG:-./.goreleaser/dockers.yaml}" \
-        --skip=validate "${@}"
+        --skip=validate "$@"
+}
+
+get-server-versions() {
+    for i in $(seq 3 5); do
+
+    git -C server checkout server-4."$i"
+
+    export SERVER_4_"$i"_PICARD="$(yq .circleci/picard -r server/images.yaml)"
+
+    done
 }
 
 # This variable is used, but shellcheck can't tell.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,8 @@
-FROM circleci/picard:agent as task-agent-image
+ARG PICARD_VERSION=agent
 
-FROM scratch as builder
+FROM circleci/picard:${PICARD_VERSION} AS task-agent-image
+
+FROM scratch AS builder
 
 ARG ARCH
 


### PR DESCRIPTION
:gear: **Issue**

**Ticket/s**: ONPREM-1222

---

:gear: **Change Description**

<!--
**Change Type**:
*Why this change? Reference the ticket and acceptance criteria if any. Specify the type of change: bug fix, new feature, breaking change, documentation update, security, etc.*
-->

New feature

**Acceptance Criteria**:

Build images for each supported server version using the correct version of picard

---

:white_check_mark: **Solution**

<!--
*What was the solution? How did you fix the issue or implement the new feature?*
-->

Pull the images.yaml list from the server repo & use that to set the version of the picard image used the build runner-init

---

:question: **Testing**

<!--
*Describe what was tested. Remember to include changes in functionality, edge cases, and enough detail that another developer can replicate your progress.*
-->

- [ ] Created and updated tests where applicable

---

:book: **Documentation Updates**

<!--
*Have any updates been made to the documentation?*
-->

- [ ] Updated related documentation, if applicable
- [ ] Updated [changelog](https://github.com/circleci/runner-init/blob/main/CHANGELOG.md)
