### PR TITLE
Move the runner smoke tester to runner-init

### DIFF
--- a/do
+++ b/do
@@ -85,6 +85,14 @@ test() {
 
 # This variable is used, but shellcheck can't tell.
 # shellcheck disable=SC2034
+help_smoke_tests="Run the smoke tests"
+smoke-tests() {
+    GOTESTSUM_FORMAT="${GOTESTSUM_FORMAT:-standard-verbose}" \
+        test -test.timeout=20m -tags smoke ./internal/testing/ci/smoke
+}
+
+# This variable is used, but shellcheck can't tell.
+# shellcheck disable=SC2034
 help_go_mod_tidy="Run 'go mod tidy' to clean up module files."
 go-mod-tidy() {
     go mod tidy -v

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/bytedance/sonic/loader v0.1.1 h1:c+e5Pt1k/cy5wMveRDyk2X4B9hF4g7an8N3z
 github.com/bytedance/sonic/loader v0.1.1/go.mod h1:ncP89zfokxS5LZrJxl5z0UJcsk4M4yY2JpfqGeCtNLU=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
+github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
+github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/circleci/ex v1.0.10766-e3be8e3 h1:WWMVWNs/A8oRfG4hXfgkxGNcOWosXH4TbjD4XVh1D0w=
 github.com/circleci/ex v1.0.10766-e3be8e3/go.mod h1:ua7B9rL+/uBQBT04MiYNZ1phYD6Qg/uqkwj4oVU3iGc=
 github.com/cloudwego/base64x v0.1.4 h1:jwCgWpFanWmN8xoIUHa2rtzmkd5J2plF/dnLS6Xd/0Y=
@@ -124,6 +126,8 @@ github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
 github.com/ugorji/go/codec v1.2.12 h1:9LC83zGrHhuUA9l16C9AHXAqEV/2wBQ4nkvumAE65EE=
 github.com/ugorji/go/codec v1.2.12/go.mod h1:UNopzCgEMSXjBc6AOMqYvWC1ktqTAfzJZUZgYf6w6lg=
+github.com/vmihailenco/go-tinylfu v0.2.2 h1:H1eiG6HM36iniK6+21n9LLpzx1G9R3DJa2UjUjbynsI=
+github.com/vmihailenco/go-tinylfu v0.2.2/go.mod h1:CutYi2Q9puTxfcolkliPq4npPuofg9N9t8JVrjzwa3Q=
 github.com/vmihailenco/msgpack/v5 v5.4.1 h1:cQriyiUvjTwOHg8QZaPihLWeRAAVoCpE00IUPn0Bjt8=
 github.com/vmihailenco/msgpack/v5 v5.4.1/go.mod h1:GaZTsDaehaPpQVyxrf5mtQlH+pc21PIudVV/E3rRQok=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=

--- a/internal/testing/ci/smoke/smoke_test.go
+++ b/internal/testing/ci/smoke/smoke_test.go
@@ -1,0 +1,96 @@
+//go:build smoke
+
+package smoke
+
+import (
+	"os"
+	"testing"
+
+	"github.com/alecthomas/kong"
+	"github.com/circleci/ex/config/secret"
+)
+
+type CLI struct {
+	CircleToken   secret.String `name:"circle-api-token" env:"CIRCLE_API_TOKEN" required:"true" help:"An API token to authenticate with the CircleCI API."`
+	TriggerSource string        `name:"trigger-source" env:"CIRCLE_BUILD_URL" default:"dev" help:"Where this pipeline was triggered from."`
+	T             string        `name:"smoke.test" short:"t"`
+
+	Tests struct {
+		Branch   string `name:"branch" env:"BRANCH" default:"main" help:"Which branch to run the tests on."`
+		Version  string `name:"version" env:"VERSION" default:"edge" help:"The runner agent version to use in the tests."`
+		IsCanary bool   `name:"is-canary" env:"IS_CANARY" default:"false" help:"Whether this is a canary or not. Some things like the Docker image repositories may differ for canaries."`
+
+		// Driver-specific parameters
+		Kubernetes `envprefix:"KUBERNETES_"`
+	} `envprefix:"SMOKE_TESTS_" embed:""`
+}
+
+type Kubernetes struct {
+	HelmChartBranch string `env:"HELM_CHART_BRANCH" default:"" help:"An optional branch name on the CircleCI-Public/container-runner-helm-chart repository. This can be used for testing a pre-release Helm chart version."`
+}
+
+var cli *CLI
+
+func TestMain(m *testing.M) {
+	cli = &CLI{}
+	_ = kong.Parse(cli)
+	os.Exit(m.Run())
+}
+
+func TestSmoke(t *testing.T) {
+	var tests = []struct {
+		name string
+
+		driver string
+		cases  []TestCase
+	}{
+		{
+			name:   "machine success",
+			driver: "machine",
+			cases: []TestCase{
+				{
+					WorkflowName:       "machine",
+					WantWorkflowStatus: "success",
+					CheckJobs:          nil,
+				},
+			},
+		},
+		{
+			name:   "kubernetes success",
+			driver: "kubernetes",
+			cases: []TestCase{
+				{
+					WorkflowName:       "kubernetes",
+					WantWorkflowStatus: "success",
+					CheckJobs:          nil,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			st := Tester{
+				AgentDriver:   tt.driver,
+				CircleToken:   cli.CircleToken,
+				TriggerSource: cli.TriggerSource,
+				Branch:        cli.Tests.Branch,
+				AgentVersion:  cli.Tests.Version,
+				IsCanary:      cli.Tests.IsCanary,
+				ExtraPipelineParameters: map[string]any{
+					"kubernetes_helm_chart_branch": cli.Tests.Kubernetes.HelmChartBranch,
+				},
+			}
+			st.Setup(t)
+
+			for _, c := range tt.cases {
+				t.Run(c.WorkflowName, func(t *testing.T) {
+					st.Execute(t, c)
+				})
+			}
+		})
+	}
+}

--- a/internal/testing/ci/smoke/tester.go
+++ b/internal/testing/ci/smoke/tester.go
@@ -40,6 +40,7 @@ func (st *Tester) Setup(t *testing.T) {
 	t.Logf("Agent driver %q", st.AgentDriver)
 	t.Logf("Agent version %q", st.AgentVersion)
 	t.Logf("Is this a canary? %t", st.IsCanary)
+	t.Logf("Extra pipeline parameters: %v", st.ExtraPipelineParameters)
 
 	pipelineResp, err := st.triggerPipeline()
 	assert.NilError(t, err)

--- a/internal/testing/ci/smoke/tester.go
+++ b/internal/testing/ci/smoke/tester.go
@@ -1,0 +1,265 @@
+package smoke
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/circleci/ex/config/secret"
+	"github.com/circleci/ex/httpclient"
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/poll"
+)
+
+const projectSlug = "github/circleci/runner-smoke-tests"
+
+type Tester struct {
+	Branch      string
+	CircleToken secret.String
+
+	TriggerSource           string
+	AgentDriver             string
+	AgentVersion            string
+	IsCanary                bool
+	ExtraPipelineParameters map[string]any
+
+	client       *httpclient.Client
+	pipelineResp pipelineResponse
+}
+
+func (st *Tester) Setup(t *testing.T) {
+	st.client = httpclient.New(httpclient.Config{
+		Name:       "runner-smoke-tests",
+		BaseURL:    "https://circleci.com/api/v2",
+		AuthHeader: "Circle-Token",
+		AuthToken:  st.CircleToken.Raw(),
+	})
+
+	t.Logf("Triggering pipeline for project %q on branch %q", projectSlug, st.Branch)
+	t.Logf("Agent driver %q", st.AgentDriver)
+	t.Logf("Agent version %q", st.AgentVersion)
+	t.Logf("Is this a canary? %t", st.IsCanary)
+
+	pipelineResp, err := st.triggerPipeline()
+	assert.NilError(t, err)
+	st.pipelineResp = pipelineResp
+
+	t.Logf("Pipeline number %d was created; checking workflows...", pipelineResp.Number)
+	t.Logf("Workflows URL: https://circleci.com/api/v2/pipeline/%s/workflow", st.pipelineResp.ID)
+}
+
+type TestCase struct {
+	WorkflowName       string
+	WantWorkflowStatus string
+	CheckJobs          func(t *testing.T, jobs []Job)
+}
+
+func (st *Tester) Execute(t *testing.T, tt TestCase) {
+	var workflow *workflow
+	isFound := false
+	i := 0
+	poll.WaitOn(t, func(t poll.LogT) poll.Result {
+		i++
+		workflows, err := st.allWorkflows(st.pipelineResp.ID)
+		if err != nil {
+			return poll.Continue("Could not get workflows for pipeline number %d: %s", st.pipelineResp.Number, err)
+		}
+
+		workflow = findWorkflow(workflows, tt.WorkflowName)
+		if workflow == nil {
+			return poll.Continue("Could not find workflow %q", tt.WorkflowName)
+		}
+
+		if !isFound {
+			t.Logf("Found workflow %q: https://circleci.com/workflow-run/%s", tt.WorkflowName, workflow.ID)
+			isFound = true
+		}
+
+		if workflow.isStillRunning() {
+			if i%300 == 0 {
+				t.Logf("Workflow %q is still running: https://circleci.com/workflow-run/%s", tt.WorkflowName, workflow.ID)
+			}
+			return poll.Continue("Workflow %q is still running: https://circleci.com/workflow-run/%s", tt.WorkflowName, workflow.ID)
+		}
+
+		if workflow.Status != tt.WantWorkflowStatus {
+			return poll.Error(fmt.Errorf("workflow %q does not have status %q\n%#v",
+				tt.WorkflowName, tt.WantWorkflowStatus, workflow))
+		}
+		return poll.Success()
+	}, poll.WithTimeout(20*time.Minute), poll.WithDelay(time.Second))
+
+	if workflow.isStillRunning() {
+		// If the workflow is still running after the tests have timed out,
+		// cancel the workflow so that we don't have wasteful concurrency consumption on tasks that will never get claimed.
+		assert.NilError(t, st.cancel(workflow.ID))
+	}
+
+	jobs, err := st.allJobs(workflow.ID)
+	assert.NilError(t, err)
+
+	if tt.CheckJobs != nil {
+		tt.CheckJobs(t, jobs.Items)
+	}
+}
+
+func findWorkflow(workflows workflowsResponse, name string) *workflow {
+	// Get the earliest matching workflow so that we can ignore any reran workflows of the same name
+	var earliestWorkflow *workflow
+	for i := range workflows.Items {
+		workflow := workflows.Items[i]
+		if workflow.Name == name {
+			if earliestWorkflow == nil || workflow.CreatedAt.Before(earliestWorkflow.CreatedAt) {
+				earliestWorkflow = &workflow
+			}
+		}
+	}
+	return earliestWorkflow
+}
+
+type pipelineRequest struct {
+	Branch     string         `json:"branch"`
+	Parameters map[string]any `json:"parameters"`
+}
+
+type pipelineResponse struct {
+	ID     string `json:"id"`
+	State  string `json:"state"`
+	Number int    `json:"number"`
+}
+
+func (st *Tester) triggerPipeline() (resp pipelineResponse, err error) {
+	parameters := st.ExtraPipelineParameters
+	parameters["driver"] = st.AgentDriver
+	parameters["trigger_source"] = st.TriggerSource
+	parameters["version"] = st.AgentVersion
+
+	req := pipelineRequest{
+		Branch:     st.Branch,
+		Parameters: parameters,
+	}
+	if st.IsCanary {
+		req.Parameters["is_canary"] = true
+	}
+	route := fmt.Sprintf("/project/%s/pipeline", projectSlug)
+	err = st.client.Call(context.Background(),
+		httpclient.NewRequest("POST", route, httpclient.Body(req), httpclient.JSONDecoder(&resp)))
+	if err != nil {
+		return resp, fmt.Errorf("error triggering pipeline: %w", err)
+	}
+	return resp, nil
+}
+
+func (st *Tester) cancel(workflowID string) error {
+	route := fmt.Sprintf("/workflow/%s/cancel", workflowID)
+	err := st.client.Call(context.Background(), httpclient.NewRequest("POST", route))
+	if err != nil {
+		return fmt.Errorf("error cancelling workflow: %w", err)
+	}
+	return nil
+}
+
+type workflow struct {
+	ID             string    `json:"id"`
+	Name           string    `json:"name"`
+	Status         string    `json:"status"`
+	PipelineID     string    `json:"pipeline_id"`
+	PipelineNumber int       `json:"pipeline_number"`
+	CreatedAt      time.Time `json:"created_at"`
+	ProjectSlug    string    `json:"project_slug"`
+}
+
+var workflowStatuses = map[string]bool{
+	"error":        true,
+	"failed":       true,
+	"success":      true,
+	"canceled":     true,
+	"unauthorized": true,
+}
+
+func (w *workflow) isStillRunning() bool {
+	_, isNotRunning := workflowStatuses[w.Status]
+	return !isNotRunning
+}
+
+type workflowsResponse struct {
+	Items         []workflow `json:"items"`
+	NextPageToken string     `json:"next_page_token"`
+}
+
+func (st *Tester) allWorkflows(pipelineID string) (all workflowsResponse, err error) {
+	nextPageToken := ""
+	for {
+		resp, err := st.getWorkflows(pipelineID, nextPageToken)
+		if err != nil {
+			return all, err
+		}
+		all.Items = append(all.Items, resp.Items...)
+		if resp.NextPageToken == "" {
+			break
+		}
+		nextPageToken = resp.NextPageToken
+	}
+	return all, nil
+}
+
+func (st *Tester) getWorkflows(pipelineID string, nextPageToken string) (resp workflowsResponse, err error) {
+	route := fmt.Sprintf("/pipeline/%s/workflow", pipelineID)
+	if nextPageToken != "" {
+		route += fmt.Sprintf("?page-token=%s", nextPageToken)
+	}
+
+	err = st.client.Call(context.Background(), httpclient.NewRequest("GET", route, httpclient.JSONDecoder(&resp)))
+	if err != nil {
+		return resp, fmt.Errorf("error getting workflows: %w", err)
+	}
+	return resp, nil
+}
+
+type Job struct {
+	CanceledBy   string   `json:"canceled_by"`
+	Dependencies []string `json:"dependencies"`
+	JobNumber    int      `json:"job_number"`
+	ID           string   `json:"id"`
+	StartedAt    string   `json:"started_at"`
+	Name         string   `json:"name"`
+	ApprovedBy   string   `json:"approved_by"`
+	ProjectSlug  string   `json:"project_slug"`
+	Status       string   `json:"status"`
+	Type         string   `json:"type"`
+	StoppedAt    string   `json:"stopped_at"`
+}
+
+type jobsResponse struct {
+	Items         []Job  `json:"items"`
+	NextPageToken string `json:"next_page_token"`
+}
+
+func (st *Tester) allJobs(workflowID string) (all jobsResponse, err error) {
+	nextPageToken := ""
+	for {
+		resp, err := st.getJobs(workflowID, nextPageToken)
+		if err != nil {
+			return all, err
+		}
+		all.Items = append(all.Items, resp.Items...)
+		if resp.NextPageToken == "" {
+			break
+		}
+		nextPageToken = resp.NextPageToken
+	}
+	return all, nil
+}
+
+func (st *Tester) getJobs(workflowID, nextPageToken string) (resp jobsResponse, err error) {
+	route := fmt.Sprintf("/workflow/%s/job", workflowID)
+	if nextPageToken != "" {
+		route += fmt.Sprintf("?page-token=%s", nextPageToken)
+	}
+	err = st.client.Call(context.Background(), httpclient.NewRequest("GET", route, httpclient.JSONDecoder(&resp)))
+	if err != nil {
+		return resp, fmt.Errorf("error getting jobs: %w", err)
+	}
+	return resp, nil
+}


### PR DESCRIPTION
:gear: **Issue**

<!-- 
**Ticket/s**: 
-->

---

:gear: **Change Description**

Copied from the `circleci-runner` repo. We'll be wanting to run these tests not only from `runner-init`, but other projects that might be in different orgs, like [the Helm chart](https://github.com/circleci-public/container-runner-helm-chart).

Having the smoke tester in this repo means we can easily clone it given that it's public.

<!--
**Change Type**:
*Why this change? Reference the ticket and acceptance criteria if any. Specify the type of change: bug fix, new feature, breaking change, documentation update, security, etc.*
-->

**Acceptance Criteria**:

---

:white_check_mark: **Solution**

<!--
*What was the solution? How did you fix the issue or implement the new feature?*
-->

---

:question: **Testing**

<!--
*Describe what was tested. Remember to include changes in functionality, edge cases, and enough detail that another developer can replicate your progress.*
-->

- [ ] Created and updated tests where applicable

---

:book: **Documentation Updates**

<!--
*Have any updates been made to the documentation?*
-->

- [ ] Updated related documentation, if applicable
- [ ] Updated [changelog](https://github.com/circleci/runner-init/blob/main/CHANGELOG.md)
