### PR TITLE
Upgrade GoReleaser to v2 and parameterize server image building

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,17 +94,25 @@ jobs:
     steps:
       - goreleaser_setup
       - docker_login
-      - run:
-          name: Check out server repo
-          command: git clone https://scotty-approver:$SCOTTY_APPROVER_TOKEN@github.com/circleci/server.git
       - notify_slack:
           header: ":goat: Release triggered"
           version: "$(<version.txt)"
       - run:
-          name: Build and maybe push images
+          name: Set SKIP_PUSH variable
           command: |
-            SKIP_PUSH=$(if [ "$CIRCLE_BRANCH" == "main" ]; then echo "false"; else echo "true"; fi) \
-              ./do images
+            echo 'export SKIP_PUSH=$(if [ "$CIRCLE_BRANCH" == "main" ]; then echo "false"; else echo "true"; fi)' >> $BASH_ENV
+      - run:
+          name: Build and maybe push images for cloud
+          command: ./do images
+      - run:
+          name: Clone the server repo
+          command: |
+            git clone "https://scotty-approver:${SCOTTY_APPROVER_TOKEN}@github.com/circleci/server.git"
+            echo 'export SERVER_REPO_PATH="$PWD/server"' >> $BASH_ENV
+      - run:
+          name: Build and maybe push images for server
+          command: ./do images-for-server
+      - notify_failing_main
 
   scan:
     executor: ccc

--- a/.goreleaser/dockers.yaml
+++ b/.goreleaser/dockers.yaml
@@ -8,101 +8,28 @@ release:
 
 dockers:
   - id: init-amd64
-    image_templates: ["circleci/runner-init:agents-amd64"]
+    image_templates: ["circleci/runner-init:agent-amd64{{.Env.IMAGE_TAG_SUFFIX}}"]
     skip_push: "{{.Env.SKIP_PUSH}}"
     dockerfile: ./docker/Dockerfile
     use: buildx
     build_flag_templates:
       - "--platform=linux/amd64"
       - "--build-arg=ARCH=amd64"
-      - "--build-arg=PICARD_VERSION=agent"
-    extra_files:
-      - ./target/bin/amd64/orchestrator
-
-  - id: init-amd64-server-4.3
-    image_templates: ["circleci/runner-init:agent-amd64-server-4.3"]
-    skip_push: "{{.Env.SKIP_PUSH}}"
-    dockerfile: ./docker/Dockerfile
-    use: buildx
-    build_flag_templates:
-      - "--platform=linux/amd64"
-      - "--build-arg=ARCH=amd64"
-      - "--build-arg=PICARD_VERSION={{ .Env.SERVER_4_3_PICARD }}"
-    extra_files:
-      - ./target/bin/amd64/orchestrator
-
-  - id: init-amd64-server-4.4
-    image_templates: ["circleci/runner-init:agent-amd64-server-4.4"]
-    skip_push: "{{.Env.SKIP_PUSH}}"
-    dockerfile: ./docker/Dockerfile
-    use: buildx
-    build_flag_templates:
-      - "--platform=linux/amd64"
-      - "--build-arg=ARCH=amd64"
-      - "--build-arg=PICARD_VERSION={{ .Env.SERVER_4_4_PICARD }}"
-    extra_files:
-      - ./target/bin/amd64/orchestrator
-
-  - id: init-amd64-server-4.5
-    image_templates: ["circleci/runner-init:agent-amd64-server-4.5"]
-    skip_push: "{{.Env.SKIP_PUSH}}"
-    dockerfile: ./docker/Dockerfile
-    use: buildx
-    build_flag_templates:
-      - "--platform=linux/amd64"
-      - "--build-arg=ARCH=amd64"
-      - "--build-arg=PICARD_VERSION={{ .Env.SERVER_4_5_PICARD }}"
+      - "--build-arg=PICARD_VERSION={{.Env.PICARD_VERSION}}"
     extra_files:
       - ./target/bin/amd64/orchestrator
 
   - id: init-arm64
-    image_templates: ["circleci/runner-init:agents-arm64"]
+    image_templates: ["circleci/runner-init:agent-arm64{{.Env.IMAGE_TAG_SUFFIX}}"]
     skip_push: "{{.Env.SKIP_PUSH}}"
     dockerfile: ./docker/Dockerfile
     use: buildx
     build_flag_templates:
       - "--platform=linux/arm64"
       - "--build-arg=ARCH=arm64"
-      - "--build-arg=PICARD_VERSION=agent"
+      - "--build-arg=PICARD_VERSION={{.Env.PICARD_VERSION}}"
     extra_files:
       - ./target/bin/arm64/orchestrator
-
-  - id: init-arm64-server-4.3
-    image_templates: ["circleci/runner-init:agent-arm64-server-4.3"]
-    skip_push: "{{.Env.SKIP_PUSH}}"
-    dockerfile: ./docker/Dockerfile
-    use: buildx
-    build_flag_templates:
-      - "--platform=linux/arm64"
-      - "--build-arg=ARCH=arm64"
-      - "--build-arg=PICARD_VERSION={{ .Env.SERVER_4_3_PICARD }}"
-    extra_files:
-      - ./target/bin/arm64/orchestrator
-
-  - id: init-arm64-server-4.4
-    image_templates: ["circleci/runner-init:agent-arm64-server-4.4"]
-    skip_push: "{{.Env.SKIP_PUSH}}"
-    dockerfile: ./docker/Dockerfile
-    use: buildx
-    build_flag_templates:
-      - "--platform=linux/arm64"
-      - "--build-arg=ARCH=arm64"
-      - "--build-arg=PICARD_VERSION={{ .Env.SERVER_4_4_PICARD }}"
-    extra_files:
-      - ./target/bin/arm64/orchestrator
-
-  - id: init-arm64-server-4.5
-    image_templates: ["circleci/runner-init:agent-arm64-server-4.5"]
-    skip_push: "{{.Env.SKIP_PUSH}}"
-    dockerfile: ./docker/Dockerfile
-    use: buildx
-    build_flag_templates:
-      - "--platform=linux/arm64"
-      - "--build-arg=ARCH=arm64"
-      - "--build-arg=PICARD_VERSION={{ .Env.SERVER_4_5_PICARD }}"
-    extra_files:
-      - ./target/bin/arm64/orchestrator
-
 
   - id: testinit-amd64
     image_templates: ["circleci/runner-init:test-agents-amd64"]
@@ -129,28 +56,10 @@ dockers:
       - ./target/bin/arm64/fake-task-agent
 
 docker_manifests:
-  - name_template: "circleci/runner-init:agents"
+  - name_template: "circleci/runner-init:agent{{.Env.IMAGE_TAG_SUFFIX}}"
     image_templates:
-      - "circleci/runner-init:agents-amd64"
-      - "circleci/runner-init:agents-arm64"
-    skip_push: "{{.Env.SKIP_PUSH}}"
-
-  - name_template: "circleci/runner-init:agent-server-4.3"
-    image_templates:
-      - "circleci/runner-init:agent-amd64-server-4.3"
-      - "circleci/runner-init:agent-arm64-server-4.3"
-    skip_push: "{{.Env.SKIP_PUSH}}"
-
-  - name_template: "circleci/runner-init:agent-server-4.4"
-    image_templates:
-      - "circleci/runner-init:agent-amd64-server-4.4"
-      - "circleci/runner-init:agent-arm64-server-4.4"
-    skip_push: "{{.Env.SKIP_PUSH}}"
-
-  - name_template: "circleci/runner-init:agent-server-4.5"
-    image_templates:
-      - "circleci/runner-init:agent-amd64-server-4.5"
-      - "circleci/runner-init:agent-arm64-server-4.5"
+      - "circleci/runner-init:agent-amd64{{.Env.IMAGE_TAG_SUFFIX}}"
+      - "circleci/runner-init:agent-arm64{{.Env.IMAGE_TAG_SUFFIX}}"
     skip_push: "{{.Env.SKIP_PUSH}}"
 
   - name_template: "circleci/runner-init:test-agents"

--- a/do
+++ b/do
@@ -3,7 +3,7 @@
 set -eu -o pipefail
 
 reportDir="test-reports"
-GORELEASER_VERSION="v1.26.2"
+GORELEASER_VERSION="v2.0.1"
 GOTESTSUM_VERSION="1.12.0"
 
 # This variable is used, but shellcheck can't tell.
@@ -29,6 +29,7 @@ help_dev_binary="Build and push the Docker images and manifests"
 images() {
     set -x
 
+    if
     get-server-versions
 
     [[ -f ./bin/goreleaser ]] || install-go-bin "github.com/goreleaser/goreleaser@latest"


### PR DESCRIPTION
:gear: **Issue**

<!-- 
**Ticket/s**: 
-->

https://circleci.atlassian.net/browse/ONPREM-1249

---

:gear: **Change Description**

While testing this upgrade of GoReleaser on my dev machine, I discovered that building images required having the server repo checked out locally. This changes that by having the server image building a separate command and also parameterizes the `build-agent` version and image tag so we can simplify the GoReleaser config.

<!--
**Change Type**:
*Why this change? Reference the ticket and acceptance criteria if any. Specify the type of change: bug fix, new feature, breaking change, documentation update, security, etc.*
-->

**Acceptance Criteria**:

---

:white_check_mark: **Solution**

<!--
*What was the solution? How did you fix the issue or implement the new feature?*
-->

---

:question: **Testing**

<!--
*Describe what was tested. Remember to include changes in functionality, edge cases, and enough detail that another developer can replicate your progress.*
-->

- [ ] Created and updated tests where applicable

---

:book: **Documentation Updates**

<!--
*Have any updates been made to the documentation?*
-->

- [ ] Updated related documentation, if applicable
- [ ] Updated [changelog](https://github.com/circleci/runner-init/blob/main/CHANGELOG.md)
