### PR TITLE
Pass configuration through a Secret environment variable [ONPREM-1263]

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -96,7 +96,7 @@ issues:
       source: '"message":'
     # Very long lines are ok if they're in CLI config
     - linters: [ lll ]
-      source: 'env:"'
+      source: 'help:"'
     # Ignore errcheck on a deferred Close
     - linters: [errcheck]
       source: ^\s*defer .*\.Close(.*)$

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ By following these guidelines, we can easily determine which changes should be i
 
 ## Edge
 
+- [#27](https://github.com/circleci/runner-init/pull/27) [INTERNAL] Pass orchestrator configuration through an environment variable from a Kubernetes Secret. This variable is stripped from the environment that is passed to the task agent command to prevent token leakage in the task environment.
 - [#26](https://github.com/circleci/runner-init/pull/26) [INTERNAL] Handle shutdown of a task with a termination grace period.
 - [#25](https://github.com/circleci/runner-init/pull/25) [INTERNAL] Implement the ability to execute a task and a custom entrypoint.
 - [#24](https://github.com/circleci/runner-init/pull/24) [INTERNAL] Add checksum validation of the task token to help detect transmission errors.

--- a/acceptance/init_test.go
+++ b/acceptance/init_test.go
@@ -22,7 +22,7 @@ func TestInit(t *testing.T) {
 	r := runner.New(
 		"SOURCE="+srcDir,
 		"DESTINATION="+destDir,
-		"SHUTDOWN_DELAY=0",
+		"CIRCLECI_GOAT_SHUTDOWN_DELAY=0",
 	)
 	res, err := r.Start(orchestratorTestBinary)
 	assert.NilError(t, err)

--- a/acceptance/task_test.go
+++ b/acceptance/task_test.go
@@ -2,8 +2,6 @@ package acceptance
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -12,14 +10,6 @@ import (
 )
 
 func TestRunTask(t *testing.T) {
-	in := stdin(t)
-	r := runner.New(
-		"SHUTDOWN_DELAY=10s",
-		"STDIN="+in.Name(),
-	)
-	res, err := r.Start(orchestratorTestBinaryRunTask)
-	assert.NilError(t, err)
-
 	goodConfig := fmt.Sprintf(`
 {
 	"cmd": [],
@@ -28,17 +18,18 @@ func TestRunTask(t *testing.T) {
 	"task_agent_path": "%v",
 	"runner_api_base_url": "https://runner.circleci.com",
 	"allocation": "testallocation",
-	"max_run_time": 60000000000,
-	"token_checksum": "ada63e98fe50eccb55036d88eda4b2c3709f53c2b65bc0335797067e9a2a5d8b"
+	"max_run_time": 60000000000
 }`, taskAgentBinary)
+
+	r := runner.New(
+		"CIRCLECI_GOAT_SHUTDOWN_DELAY=10s",
+		"CIRCLECI_GOAT_CONFIG="+goodConfig,
+	)
+	res, err := r.Start(orchestratorTestBinaryRunTask)
+	assert.NilError(t, err)
 
 	t.Run("Probe for readiness", func(t *testing.T) {
 		assert.NilError(t, res.Ready("admin", time.Second*20))
-	})
-
-	t.Run("Load config", func(t *testing.T) {
-		_, err := in.Write([]byte(goodConfig))
-		assert.NilError(t, err)
 	})
 
 	t.Run("Run task", func(t *testing.T) {
@@ -52,16 +43,4 @@ func TestRunTask(t *testing.T) {
 	})
 
 	// TODO: Add more test cases...
-}
-
-func stdin(t *testing.T) *os.File {
-	t.Helper()
-
-	f, err := os.Create(filepath.Join(t.TempDir(), "fakestdin")) //#nosec:G304 // this is just for testing
-	assert.NilError(t, err)
-	t.Cleanup(func() {
-		assert.NilError(t, f.Close())
-	})
-
-	return f
 }

--- a/cmd/orchestrator/help_test.go
+++ b/cmd/orchestrator/help_test.go
@@ -49,6 +49,7 @@ func help(t *testing.T, cli interface{}) string {
 	w := bytes.NewBuffer(nil)
 	rc := -1
 	app, err := kong.New(cli,
+		kong.DefaultEnvars("CIRCLECI_GOAT"),
 		kong.Name("test-app"),
 		kong.Writers(w, w),
 		kong.Exit(func(i int) {

--- a/cmd/orchestrator/testdata/help.txt
+++ b/cmd/orchestrator/testdata/help.txt
@@ -2,8 +2,10 @@ Usage: test-app <command> [flags]
 
 Flags:
   -h, --help                 Show context-sensitive help.
-  -v, --version              Print version information and quit.
-      --shutdown-delay=0s    Delay shutdown by this amount ($SHUTDOWN_DELAY).
+  -v, --version              Print version information and quit
+                             ($CIRCLECI_GOAT_VERSION).
+      --shutdown-delay=0s    Delay shutdown by this amount
+                             ($CIRCLECI_GOAT_SHUTDOWN_DELAY).
 
 Commands:
   init [<source> [<destination>]] [flags]

--- a/cmd/orchestrator/testdata/run-task.txt
+++ b/cmd/orchestrator/testdata/run-task.txt
@@ -4,7 +4,7 @@ Flags:
   -h, --help    Show context-sensitive help.
       --termination-grace-period=20s
                 How long the agent will wait for the task to complete if
-                interrupted ($TERMINATION_GRACE_PERIOD).
+                interrupted ($CIRCLECI_GOAT_TERMINATION_GRACE_PERIOD).
       --health-check-addr="localhost:7623"
                 Address for the health check API to listen on
-                ($HEALTH_CHECK_ADDR).
+                ($CIRCLECI_GOAT_HEALTH_CHECK_ADDR).

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ toolchain go1.22.4
 require (
 	github.com/alecthomas/kong v0.9.0
 	github.com/goccy/go-json v0.10.2
-	github.com/google/go-cmp v0.6.0
 	gotest.tools/v3 v3.5.1
 )
 
@@ -22,6 +21,7 @@ require (
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.20.0 // indirect
+	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/hellofresh/health-go/v5 v5.5.3 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.7 // indirect


### PR DESCRIPTION
:gear: **Issue**

<!-- 
**Ticket/s**: 
-->

https://circleci.atlassian.net/browse/ONPREM-1263

---

:gear: **Change Description**

Having thought about this a bit more, we don't need to pass the orchestrator configuration over stdin using the attach API. We can instead inject it as an environment variable from the Kubernetes Secret associated with the task. We can then unset this environment variable and/or prevent it was being passed to the task agent command.

<!--
**Change Type**:
*Why this change? Reference the ticket and acceptance criteria if any. Specify the type of change: bug fix, new feature, breaking change, documentation update, security, etc.*
-->

**Acceptance Criteria**:

---

:white_check_mark: **Solution**

<!--
*What was the solution? How did you fix the issue or implement the new feature?*
-->

---

:question: **Testing**

<!--
*Describe what was tested. Remember to include changes in functionality, edge cases, and enough detail that another developer can replicate your progress.*
-->

- [ ] Created and updated tests where applicable

---

:book: **Documentation Updates**

<!--
*Have any updates been made to the documentation?*
-->

- [ ] Updated related documentation, if applicable
- [ ] Updated [changelog](https://github.com/circleci/runner-init/blob/main/CHANGELOG.md)
