### PR TITLE
Fix data race in orchestrator tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ jobs:
     executor: go
     steps:
       - setup
-      - run: ./do test
+      - run: ./do test ./... -count 3
       - notify_failing_main
 
   build:

--- a/task/orchestrator_test.go
+++ b/task/orchestrator_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -13,6 +14,8 @@ import (
 	"gotest.tools/v3/assert"
 	"gotest.tools/v3/assert/cmp"
 )
+
+var testOnce sync.Once
 
 func TestOrchestrator(t *testing.T) {
 	if os.Getenv("BE_TASK_AGENT") == "true" {
@@ -22,7 +25,10 @@ func TestOrchestrator(t *testing.T) {
 		return
 	}
 
-	reapTime = 0 // set the process reap time to 0 to prevent interference between test cases
+	testOnce.Do(func() {
+		// Set the process reap time to 0 to prevent interference between test cases
+		reapTime = 0
+	})
 
 	testPath := os.Args[0]
 	scratchDir := t.TempDir()


### PR DESCRIPTION
:gear: **Issue**

<!-- 
**Ticket/s**: 
-->

---

:gear: **Change Description**

Should prevent this data race when running the tests with `-count` > 0:

```
=== Failed
=== FAIL: task TestOrchestrator (3.64s)
==================
WARNING: DATA RACE
Write at 0x000001202548 by goroutine 50:
  github.com/circleci/runner-init/task.TestOrchestrator()
      /home/christian/git-projects/runner-init/task/orchestrator_test.go:29 +0x7e
  testing.tRunner()
      /home/christian/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.5.linux-amd64/src/testing/testing.go:1689 +0x21e
  testing.(*T).Run.gowrap1()
      /home/christian/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.5.linux-amd64/src/testing/testing.go:1742 +0x44

Previous read at 0x000001202548 by goroutine 42:
  github.com/circleci/runner-init/task.(*Orchestrator).reapChildProcesses()
      /home/christian/git-projects/runner-init/task/orchestrator.go:227 +0x16a
  github.com/circleci/runner-init/task.(*Orchestrator).Run.gowrap1()
      /home/christian/git-projects/runner-init/task/orchestrator.go:45 +0x4f

Goroutine 50 (running) created at:
  testing.(*T).Run()
      /home/christian/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.5.linux-amd64/src/testing/testing.go:1742 +0x825
  testing.runTests.func1()
      /home/christian/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.5.linux-amd64/src/testing/testing.go:2161 +0x85
  testing.tRunner()
      /home/christian/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.5.linux-amd64/src/testing/testing.go:1689 +0x21e
  testing.runTests()
      /home/christian/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.5.linux-amd64/src/testing/testing.go:2159 +0x8be
  testing.(*M).Run()
      /home/christian/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.5.linux-amd64/src/testing/testing.go:2027 +0xf17
  main.main()
      _testmain.go:51 +0x2bd

Goroutine 42 (finished) created at:
  github.com/circleci/runner-init/task.(*Orchestrator).Run()
      /home/christian/git-projects/runner-init/task/orchestrator.go:45 +0x157
  github.com/circleci/runner-init/task.TestOrchestrator.func2()
      /home/christian/git-projects/runner-init/task/orchestrator_test.go:114 +0x458
  testing.tRunner()
      /home/christian/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.5.linux-amd64/src/testing/testing.go:1689 +0x21e
  testing.(*T).Run.gowrap1()
      /home/christian/go/pkg/mod/golang.org/toolchain@v0.0.1-go1.22.5.linux-amd64/src/testing/testing.go:1742 +0x44
==================
    testing.go:1398: race detected during execution of test

```

<!--
**Change Type**:
*Why this change? Reference the ticket and acceptance criteria if any. Specify the type of change: bug fix, new feature, breaking change, documentation update, security, etc.*
-->

**Acceptance Criteria**:

---

:white_check_mark: **Solution**

<!--
*What was the solution? How did you fix the issue or implement the new feature?*
-->

---

:question: **Testing**

<!--
*Describe what was tested. Remember to include changes in functionality, edge cases, and enough detail that another developer can replicate your progress.*
-->

- [ ] Created and updated tests where applicable

---

:book: **Documentation Updates**

<!--
*Have any updates been made to the documentation?*
-->

- [ ] Updated related documentation, if applicable
- [ ] Updated [changelog](https://github.com/circleci/runner-init/blob/main/CHANGELOG.md)
