### PR TITLE
Add position args to init command match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ By following these guidelines, we can easily determine which changes should be i
 
 ## Edge
 
+- [#39](https://github.com/circleci/runner-init/pull/39) [INTERNAL] Fix `init` command matching on startup 
 - [#37](https://github.com/circleci/runner-init/pull/37) [INTERNAL] Refactored command execution structure within the orchestrator and ensured cleanup of the child process group spawned by the task agent.
 - [#36](https://github.com/circleci/runner-init/pull/36) [INTERNAL] Integrate the runner API client in the task orchestrator. This enables retrying or reporting infrastructure failures as appropriate.
 - [#33](https://github.com/circleci/runner-init/pull/33) [INTERNAL] Start signing the init images and manifests using [Cosign](https://docs.sigstore.dev/about/overview/).

--- a/cmd/orchestrator/main.go
+++ b/cmd/orchestrator/main.go
@@ -73,6 +73,8 @@ func run(version, date string) (err error) {
 
 	switch kongCtx.Command() {
 	case "init":
+		fallthrough
+	case "init <source> <destination>":
 		c := cli.Init
 		sys.AddService(func(_ context.Context) error {
 			defer cancel()


### PR DESCRIPTION
:gear: **Issue**

<!-- 
**Ticket/s**: 
-->

---

:gear: **Change Description**

 Bug fix

<!--
**Change Type**:
*Why this change? Reference the ticket and acceptance criteria if any. Specify the type of change: bug fix, new feature, breaking change, documentation update, security, etc.*
-->

**Acceptance Criteria**:

Get the init command working

---

:white_check_mark: **Solution**

Kong includes the positional args in `<>` if they're there (Ref: https://github.com/alecthomas/kong?#introduction)
This was passing the acceptance tests as these use env vars so the kong command is just `init`.

Add another case matcher using the positional commands and fall through from the plain `init` case into that one

<!--
*What was the solution? How did you fix the issue or implement the new feature?*
-->

---

:question: **Testing**

<!--
*Describe what was tested. Remember to include changes in functionality, edge cases, and enough detail that another developer can replicate your progress.*
-->

- [ ] Created and updated tests where applicable - N/A. Manually tested the startup command

---

:book: **Documentation Updates**

<!--
*Have any updates been made to the documentation?*
-->

- [ ] Updated related documentation, if applicable
- [ ] Updated [changelog](https://github.com/circleci/runner-init/blob/main/CHANGELOG.md)
