### PR TITLE
Rename fake task agent in test image dockerfile

### DIFF
--- a/docker/test.Dockerfile
+++ b/docker/test.Dockerfile
@@ -3,7 +3,7 @@ FROM scratch as builder
 ARG ARCH
 
 COPY ./target/bin/${ARCH}/orchestrator /
-COPY ./target/bin/${ARCH}/fake-task-agent /
+COPY ./target/bin/${ARCH}/fake-task-agent /circleci-agent
 
 FROM scratch
 


### PR DESCRIPTION
:gear: **Issue**

<!-- 
**Ticket/s**: 
-->

---

:gear: **Change Description**

The init command expects the agent to be called `circleci-agent` so the fake task agent needs to be called this in the testing image.

<!--
**Change Type**:
*Why this change? Reference the ticket and acceptance criteria if any. Specify the type of change: bug fix, new feature, breaking change, documentation update, security, etc.*
-->

**Acceptance Criteria**:

---

:white_check_mark: **Solution**

<!--
*What was the solution? How did you fix the issue or implement the new feature?*
-->

---

:question: **Testing**

<!--
*Describe what was tested. Remember to include changes in functionality, edge cases, and enough detail that another developer can replicate your progress.*
-->

- [ ] Created and updated tests where applicable

---

:book: **Documentation Updates**

<!--
*Have any updates been made to the documentation?*
-->

- [ ] Updated related documentation, if applicable
- [ ] Updated [changelog](https://github.com/circleci/runner-init/blob/main/CHANGELOG.md)
