### PR TITLE
Correctly set user's home directory if switching users [ONPREM-1379]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ By following these guidelines, we can easily determine which changes should be i
 
 ## Edge
 
+- [#42](https://github.com/circleci/runner-init/pull/42) [INTERNAL] Correctly configure user's home directory when switching users to execute task-agent.
 - [#39](https://github.com/circleci/runner-init/pull/39) [INTERNAL] Fix `init` command matching on startup 
 - [#37](https://github.com/circleci/runner-init/pull/37) [INTERNAL] Refactored command execution structure within the orchestrator and ensured cleanup of the child process group spawned by the task agent.
 - [#36](https://github.com/circleci/runner-init/pull/36) [INTERNAL] Integrate the runner API client in the task orchestrator. This enables retrying or reporting infrastructure failures as appropriate.

--- a/task/cmd/cmd.go
+++ b/task/cmd/cmd.go
@@ -121,7 +121,10 @@ func newCmd(ctx context.Context, argv []string, user string, env ...string) *exe
 
 func maybeSwitchUser(ctx context.Context, cmd *exec.Cmd, username string) {
 	usr, err := user.Lookup(username)
+
 	if err == nil {
+		cmd.Env = append(cmd.Env, "HOME="+usr.HomeDir)
+
 		uid, _ := strconv.Atoi(usr.Uid)
 		gid, _ := strconv.Atoi(usr.Gid)
 		cmd.SysProcAttr.Credential = &syscall.Credential{Uid: uint32(uid), Gid: uint32(gid)}


### PR DESCRIPTION
:gear: **Issue**

<!-- 
**Ticket/s**: 
-->

---

:gear: **Change Description**

Correctly set the `$HOME` environment variable when switching users. Discovered this issue while integrating container-agent with GOAT.

<!--
**Change Type**:
*Why this change? Reference the ticket and acceptance criteria if any. Specify the type of change: bug fix, new feature, breaking change, documentation update, security, etc.*
-->

**Acceptance Criteria**:

---

:white_check_mark: **Solution**

<!--
*What was the solution? How did you fix the issue or implement the new feature?*
-->

---

:question: **Testing**

<!--
*Describe what was tested. Remember to include changes in functionality, edge cases, and enough detail that another developer can replicate your progress.*
-->

- [ ] Created and updated tests where applicable

---

:book: **Documentation Updates**

<!--
*Have any updates been made to the documentation?*
-->

- [ ] Updated related documentation, if applicable
- [ ] Updated [changelog](https://github.com/circleci/runner-init/blob/main/CHANGELOG.md)
