### PR TITLE
[ONPREM-1384] Remove localhost from healthcheck addr

### DIFF
--- a/cmd/orchestrator/main.go
+++ b/cmd/orchestrator/main.go
@@ -37,7 +37,7 @@ type initCmd struct {
 
 type runTaskCmd struct {
 	TerminationGracePeriod time.Duration `default:"20s" help:"How long the agent will wait for the task to complete if interrupted."`
-	HealthCheckAddr        string        `default:"localhost:7623" help:"Address for the health check API to listen on."`
+	HealthCheckAddr        string        `default:":7623" help:"Address for the health check API to listen on."`
 
 	// Task environment configuration should be injected through a Kubernetes Secret
 	Config task.Config `required:"" hidden:"-"`

--- a/cmd/orchestrator/testdata/run-task.txt
+++ b/cmd/orchestrator/testdata/run-task.txt
@@ -5,6 +5,6 @@ Flags:
       --termination-grace-period=20s
                 How long the agent will wait for the task to complete if
                 interrupted ($CIRCLECI_GOAT_TERMINATION_GRACE_PERIOD).
-      --health-check-addr="localhost:7623"
+      --health-check-addr=":7623"
                 Address for the health check API to listen on
                 ($CIRCLECI_GOAT_HEALTH_CHECK_ADDR).


### PR DESCRIPTION
:gear: **Issue**

<!-- 
**Ticket/s**:  
-->
ONPREM-1384

---

:gear: **Change Description**

Bug Fix
<!--
**Change Type**: Bug Fix
*Why this change? Reference the ticket and acceptance criteria if any. Specify the type of change: bug fix, new feature, breaking change, documentation update, security, etc.*
-->

**Acceptance Criteria**:

---

:white_check_mark: **Solution**

Setting the host to localhost in the healthcheck server will cause the kubelet connections to be refused. Just specifying the port sets the host to `0.0.0.0` which seems to work

<!--
*What was the solution? How did you fix the issue or implement the new feature?*
-->

---

:question: **Testing**

<!--
*Describe what was tested. Remember to include changes in functionality, edge cases, and enough detail that another developer can replicate your progress.*
-->

- [ ] Created and updated tests where applicable

---

:book: **Documentation Updates**

<!--
*Have any updates been made to the documentation?*
-->

- [ ] Updated related documentation, if applicable
- [ ] Updated [changelog](https://github.com/circleci/runner-init/blob/main/CHANGELOG.md)
