### PR TITLE
Prevent port conflict

### DIFF
--- a/acceptance/task_test.go
+++ b/acceptance/task_test.go
@@ -24,6 +24,7 @@ func TestRunTask(t *testing.T) {
 	r := runner.New(
 		"CIRCLECI_GOAT_SHUTDOWN_DELAY=10s",
 		"CIRCLECI_GOAT_CONFIG="+goodConfig,
+		"CIRCLECI_GOAT_HEALTH_CHECK_ADDR=:7624",
 	)
 	res, err := r.Start(orchestratorTestBinaryRunTask)
 	assert.NilError(t, err)


### PR DESCRIPTION
Our dogfood GOAT runner binds to the same port

:gear: **Issue**

<!-- 
**Ticket/s**: 
-->

---

:gear: **Change Description**

<!--
**Change Type**:
*Why this change? Reference the ticket and acceptance criteria if any. Specify the type of change: bug fix, new feature, breaking change, documentation update, security, etc.*
-->

**Acceptance Criteria**:

---

:white_check_mark: **Solution**

<!--
*What was the solution? How did you fix the issue or implement the new feature?*
-->

---

:question: **Testing**

<!--
*Describe what was tested. Remember to include changes in functionality, edge cases, and enough detail that another developer can replicate your progress.*
-->

- [ ] Created and updated tests where applicable

---

:book: **Documentation Updates**

<!--
*Have any updates been made to the documentation?*
-->

- [ ] Updated related documentation, if applicable
- [ ] Updated [changelog](https://github.com/circleci/runner-init/blob/main/CHANGELOG.md)
