### PR TITLE
Shorten default grace period

### DIFF
--- a/cmd/orchestrator/main.go
+++ b/cmd/orchestrator/main.go
@@ -36,7 +36,7 @@ type initCmd struct {
 }
 
 type runTaskCmd struct {
-	TerminationGracePeriod time.Duration `default:"20s" help:"How long the agent will wait for the task to complete if interrupted."`
+	TerminationGracePeriod time.Duration `default:"10s" help:"How long the agent will wait for the task to complete if interrupted."`
 	HealthCheckAddr        string        `default:":7623" help:"Address for the health check API to listen on."`
 
 	// Task environment configuration should be injected through a Kubernetes Secret

--- a/cmd/orchestrator/testdata/run-task.txt
+++ b/cmd/orchestrator/testdata/run-task.txt
@@ -2,7 +2,7 @@ Usage: test-app [flags]
 
 Flags:
   -h, --help    Show context-sensitive help.
-      --termination-grace-period=20s
+      --termination-grace-period=10s
                 How long the agent will wait for the task to complete if
                 interrupted ($CIRCLECI_GOAT_TERMINATION_GRACE_PERIOD).
       --health-check-addr=":7623"


### PR DESCRIPTION
:gear: **Issue**

<!-- 
**Ticket/s**: 
-->

---

:gear: **Change Description**

Found the existing grace period a tad bit too long when using unsafe retries with the default `terminationGracePeriodSeconds` of the container.

<!--
**Change Type**:
*Why this change? Reference the ticket and acceptance criteria if any. Specify the type of change: bug fix, new feature, breaking change, documentation update, security, etc.*
-->

**Acceptance Criteria**:

---

:white_check_mark: **Solution**

<!--
*What was the solution? How did you fix the issue or implement the new feature?*
-->

---

:question: **Testing**

<!--
*Describe what was tested. Remember to include changes in functionality, edge cases, and enough detail that another developer can replicate your progress.*
-->

- [ ] Created and updated tests where applicable

---

:book: **Documentation Updates**

<!--
*Have any updates been made to the documentation?*
-->

- [ ] Updated related documentation, if applicable
- [ ] Updated [changelog](https://github.com/circleci/runner-init/blob/main/CHANGELOG.md)
