### PR TITLE
Add ability to set the CircleCI host for the smoke tester [ONPREM-1371]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,8 +114,9 @@ jobs:
       - run:
           name: Build and push dev images for use in the smoke tests
           command: |
-            echo "export IMAGE_TAG_SUFFIX=\"-${CIRCLE_BUILD_NUM}-$(git rev-parse --short HEAD)\"" >> /tmp/workspace/environment
+            echo "export IMAGE_TAG_SUFFIX=\"-${CIRCLE_BUILD_NUM}-$(git rev-parse --short HEAD)\"" >>/tmp/workspace/environment
             source /tmp/workspace/environment
+
             SKIP_PUSH='false' \
               SKIP_PUSH_TEST_AGENT='true' \
               ./do images
@@ -187,35 +188,20 @@ jobs:
       - notify_failing_main
 
   smoke-tests:
-    parameters:
-      smoke_tests_branch:
-        description: "The branch in the `runner-smoke-tests` repo to run the smoke tests against."
-        type: string
-        default: "main"
-      version:
-        description: "The version of the runner to test."
-        type: string
-        default: "experimental"
-      k8s_helm_chart_branch:
-        description: "The circleci-runner helm chart repo branch to run the smoke tests against."
-        type: string
-        default: "main"
     executor: go
-    environment:
-      SMOKE_TESTS_BRANCH: "<< parameters.smoke_tests_branch >>"
     steps:
       - checkout
       - attach_workspace:
           at: /tmp/workspace
       - run:
-          name: "Run the runner smoke tests in the `circleci/runner-smoke-tests` repo on branch `<< parameters.smoke_tests_branch >>`"
+          name: "Run the runner smoke tests in the `circleci/runner-smoke-tests` repo"
           command: |
             source /tmp/workspace/environment
-            SMOKE_TESTS_VERSION="<< parameters.version >>" \
-            SMOKE_TESTS_KUBERNETES_RUNNER_INIT_TAG="agent$IMAGE_TAG_SUFFIX" \
-            SMOKE_TESTS_KUBERNETES_HELM_CHART_BRANCH="<< parameters.k8s_helm_chart_branch >>" \
-            SMOKE_TESTS_MACHINE_SKIP=true \
-            ./do smoke-tests
+
+            SMOKE_TESTS_VERSION="experimental" \
+              SMOKE_TESTS_KUBERNETES_RUNNER_INIT_TAG="agent${IMAGE_TAG_SUFFIX}" \
+              SMOKE_TESTS_MACHINE_SKIP=true \
+              ./do smoke-tests
       - notify_failing_main
 
 commands:

--- a/internal/testing/ci/smoke/smoke_test.go
+++ b/internal/testing/ci/smoke/smoke_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 type CLI struct {
+	CircleHost    string        `name:"circle-host" env:"CIRCLE_HOST" default:"https://circleci.com" help:"URL to your CircleCI host."`
 	CircleToken   secret.String `name:"circle-api-token" env:"CIRCLE_API_TOKEN" required:"true" help:"An API token to authenticate with the CircleCI API."`
 	TriggerSource string        `name:"trigger-source" env:"CIRCLE_BUILD_URL" default:"dev" help:"Where this pipeline was triggered from."`
 	T             string        `name:"smoke.test" short:"t"`
@@ -89,6 +90,7 @@ func TestSmoke(t *testing.T) {
 
 			st := Tester{
 				AgentDriver:   tt.driver,
+				CircleHost:    cli.CircleHost,
 				CircleToken:   cli.CircleToken,
 				TriggerSource: cli.TriggerSource,
 				Branch:        cli.Tests.Branch,

--- a/internal/testing/ci/smoke/tester.go
+++ b/internal/testing/ci/smoke/tester.go
@@ -16,6 +16,7 @@ const projectSlug = "github/circleci/runner-smoke-tests"
 
 type Tester struct {
 	Branch      string
+	CircleHost  string
 	CircleToken secret.String
 
 	TriggerSource           string
@@ -31,7 +32,7 @@ type Tester struct {
 func (st *Tester) Setup(t *testing.T) {
 	st.client = httpclient.New(httpclient.Config{
 		Name:       "runner-smoke-tests",
-		BaseURL:    "https://circleci.com/api/v2",
+		BaseURL:    st.CircleHost + "/api/v2",
 		AuthHeader: "Circle-Token",
 		AuthToken:  st.CircleToken.Raw(),
 	})


### PR DESCRIPTION
:gear: **Issue**

[Jira: ](https://circleci.atlassian.net/browse/ONPREM-1371)

<!-- 
**Ticket/s**: 
-->

---

:gear: **Change Description**

This is required for us to be able to trigger the smoke tests in K9s.

<!--
**Change Type**:
*Why this change? Reference the ticket and acceptance criteria if any. Specify the type of change: bug fix, new feature, breaking change, documentation update, security, etc.*
-->

**Acceptance Criteria**:

---

:white_check_mark: **Solution**

<!--
*What was the solution? How did you fix the issue or implement the new feature?*
-->

---

:question: **Testing**

<!--
*Describe what was tested. Remember to include changes in functionality, edge cases, and enough detail that another developer can replicate your progress.*
-->

- [ ] Created and updated tests where applicable

---

:book: **Documentation Updates**

<!--
*Have any updates been made to the documentation?*
-->

- [ ] Updated related documentation, if applicable
- [ ] Updated [changelog](https://github.com/circleci/runner-init/blob/main/CHANGELOG.md)
