### PR TITLE
add temporary simple config for webhook triggers

### DIFF
--- a/.circleci/webhook.yml
+++ b/.circleci/webhook.yml
@@ -1,0 +1,11 @@
+version: 2.1
+workflows:
+  webhook:
+    jobs:
+      - bonjour-mond
+jobs:
+  bonjour-mond:
+    docker:
+      - image: alpine:latest
+    steps:
+      - run: echo "bonjour mond, a webhook triggered me"


### PR DESCRIPTION
There's some breakage for needed pipeline variables for the docker webhook. This PR adds a simple temporary config to be used for the webhook triggers so that the pipeline isn't full of failed builds from task-agent image pushes. 