### PR TITLE
Optionally trigger driver smoke tests on different CircleCI hosts

### DIFF
--- a/internal/testing/ci/smoke/smoke_test.go
+++ b/internal/testing/ci/smoke/smoke_test.go
@@ -4,6 +4,7 @@ package smoke
 
 import (
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/alecthomas/kong"
@@ -11,8 +12,8 @@ import (
 )
 
 type CLI struct {
-	CircleHost    string        `name:"circle-host" env:"CIRCLE_HOST" default:"https://circleci.com" help:"URL to your CircleCI host."`
-	CircleToken   secret.String `name:"circle-api-token" env:"CIRCLE_API_TOKEN" required:"true" help:"An API token to authenticate with the CircleCI API."`
+	CircleHost    string        `name:"circle-host" env:"CIRCLE_HOST" help:"The URL of your CircleCI host. This setting takes precedence over individual driver configurations and applies universally to all test cases."`
+	CircleToken   secret.String `name:"circle-api-token" env:"CIRCLE_API_TOKEN" help:"An API token to authenticate with the CircleCI API. This setting overrides individual driver configurations and is applied to all test cases."`
 	TriggerSource string        `name:"trigger-source" env:"CIRCLE_BUILD_URL" default:"dev" help:"Where this pipeline was triggered from."`
 	T             string        `name:"smoke.test" short:"t"`
 
@@ -28,10 +29,16 @@ type CLI struct {
 }
 
 type Machine struct {
+	CircleHost  string        `name:"circle-host" env:"CIRCLE_HOST" default:"https://circleci.com" help:"URL to your CircleCI host for the machine tests."`
+	CircleToken secret.String `name:"circle-api-token" env:"CIRCLE_API_TOKEN" required:"true" help:"An API token to authenticate with the CircleCI API for the machine tests."`
+
 	Skip bool `env:"SKIP" help:"Skip tests for the machine driver."`
 }
 
 type Kubernetes struct {
+	CircleHost  string        `name:"circle-host" env:"CIRCLE_HOST" default:"https://k9s.sphereci.com" help:"URL to your CircleCI host for the Kubernetes tests."`
+	CircleToken secret.String `name:"circle-api-token" env:"CIRCLE_API_TOKEN" required:"true" help:"An API token to authenticate with the CircleCI API for the Kubernetes tests."`
+
 	Skip            bool   `env:"SKIP" help:"Skip tests for the Kubernetes driver."`
 	RunnerInitTag   string `env:"RUNNER_INIT_TAG" default:"" help:"The runner-init image tag to use in the smoke tests."`
 	HelmChartBranch string `env:"HELM_CHART_BRANCH" default:"" help:"An optional branch name on the CircleCI-Public/container-runner-helm-chart repository. This can be used for testing a pre-release Helm chart version."`
@@ -41,7 +48,17 @@ var cli *CLI
 
 func TestMain(m *testing.M) {
 	cli = &CLI{}
-	_ = kong.Parse(cli)
+	_ = kong.Parse(cli, kong.Resolvers(
+		kong.ResolverFunc(func(context *kong.Context, parent *kong.Path, flag *kong.Flag) (interface{}, error) {
+			if strings.HasSuffix(flag.Name, "circle-host") && cli.CircleHost != "" {
+				return cli.CircleHost, nil
+			}
+			if strings.HasSuffix(flag.Name, "circle-api-token") && cli.CircleToken.Raw() != "" {
+				return cli.CircleToken.Raw(), nil
+			}
+			return nil, nil
+		}),
+	))
 	os.Exit(m.Run())
 }
 
@@ -49,14 +66,18 @@ func TestSmoke(t *testing.T) {
 	var tests = []struct {
 		name string
 
-		driver string
-		skip   bool
-		cases  []TestCase
+		driver      string
+		circleHost  string
+		circleToken secret.String
+		skip        bool
+		cases       []TestCase
 	}{
 		{
-			name:   "machine success",
-			driver: "machine",
-			skip:   cli.Tests.Machine.Skip,
+			name:        "machine success",
+			driver:      "machine",
+			circleHost:  cli.Tests.Machine.CircleHost,
+			circleToken: cli.Tests.Machine.CircleToken,
+			skip:        cli.Tests.Machine.Skip,
 			cases: []TestCase{
 				{
 					WorkflowName:       "machine",
@@ -66,9 +87,11 @@ func TestSmoke(t *testing.T) {
 			},
 		},
 		{
-			name:   "kubernetes success",
-			driver: "kubernetes",
-			skip:   cli.Tests.Kubernetes.Skip,
+			name:        "kubernetes success",
+			driver:      "kubernetes",
+			circleHost:  cli.Tests.Kubernetes.CircleHost,
+			circleToken: cli.Tests.Kubernetes.CircleToken,
+			skip:        cli.Tests.Kubernetes.Skip,
 			cases: []TestCase{
 				{
 					WorkflowName:       "kubernetes",
@@ -90,8 +113,8 @@ func TestSmoke(t *testing.T) {
 
 			st := Tester{
 				AgentDriver:   tt.driver,
-				CircleHost:    cli.CircleHost,
-				CircleToken:   cli.CircleToken,
+				CircleHost:    tt.circleHost,
+				CircleToken:   tt.circleToken,
 				TriggerSource: cli.TriggerSource,
 				Branch:        cli.Tests.Branch,
 				AgentVersion:  cli.Tests.Version,

--- a/internal/testing/ci/smoke/tester.go
+++ b/internal/testing/ci/smoke/tester.go
@@ -37,7 +37,7 @@ func (st *Tester) Setup(t *testing.T) {
 		AuthToken:  st.CircleToken.Raw(),
 	})
 
-	t.Logf("Triggering pipeline for project %q on branch %q", projectSlug, st.Branch)
+	t.Logf("Triggering pipeline for project %q on branch %q on host %q", projectSlug, st.Branch, st.CircleHost)
 	t.Logf("Agent driver %q", st.AgentDriver)
 	t.Logf("Agent version %q", st.AgentVersion)
 	t.Logf("Extra pipeline parameters: %v", st.ExtraPipelineParameters)


### PR DESCRIPTION
This is so we can trigger the Kubernetes driver tests in K9s, the machine driver tests on cloud, and so forth

:gear: **Issue**

<!-- 
**Ticket/s**: 
-->

---

:gear: **Change Description**

<!--
**Change Type**:
*Why this change? Reference the ticket and acceptance criteria if any. Specify the type of change: bug fix, new feature, breaking change, documentation update, security, etc.*
-->

**Acceptance Criteria**:

---

:white_check_mark: **Solution**

<!--
*What was the solution? How did you fix the issue or implement the new feature?*
-->

---

:question: **Testing**

<!--
*Describe what was tested. Remember to include changes in functionality, edge cases, and enough detail that another developer can replicate your progress.*
-->

- [ ] Created and updated tests where applicable

---

:book: **Documentation Updates**

<!--
*Have any updates been made to the documentation?*
-->

- [ ] Updated related documentation, if applicable
- [ ] Updated [changelog](https://github.com/circleci/runner-init/blob/main/CHANGELOG.md)
