### PR TITLE
[ONPREM-1818] Add timeout for wait-for-readiness check on startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ By following these guidelines, we can easily determine which changes should be i
 
 ## Edge
 
+- [#97](https://github.com/circleci/runner-init/pull/97) Add timeout for the "wait-for-readiness" check on startup. This is so that GOAT doesn't wait indefinitely if there's a problem, ensuring a timely reaping of the task pod.
 - [#89](https://github.com/circleci/runner-init/pull/89) [INTERNAL] Add an option to wait for a readiness file, which is used via a shared volume to signal the readiness of all containers in the task pod.
 - [#71](https://github.com/circleci/runner-init/pull/71) [INTERNAL] Bump `ex` to `v1.0.12715-ada3e6b` and Go to `1.23`, which also required a bump in `golangci-lint` to `1.62.0` and addressing new lint errors that came along with that.
 - [#54](https://github.com/circleci/runner-init/pull/54) [INTERNAL] Forward signals from the task orchestrator (PID 1) to the custom command.

--- a/task/orchestrator_test.go
+++ b/task/orchestrator_test.go
@@ -316,6 +316,18 @@ func TestOrchestrator_waitForReadiness(t *testing.T) {
 		err := o.waitForReadiness(ctx)
 		assert.NilError(t, err)
 	})
+
+	t.Run("timed out", func(t *testing.T) {
+		ctx := testcontext.Background()
+		originalTimeout := waitForReadinessTimeout
+		waitForReadinessTimeout = 1 * time.Nanosecond
+		t.Cleanup(func() { waitForReadinessTimeout = originalTimeout })
+
+		o := Orchestrator{}
+
+		err := o.waitForReadiness(ctx)
+		assert.Check(t, cmp.ErrorContains(err, "context deadline exceeded"))
+	})
 }
 
 func beFakeTaskAgent(t *testing.T) {


### PR DESCRIPTION
:gear: **Issue**
https://circleci.atlassian.net/browse/ONPREM-1818
<!-- 
**Ticket/s**: 
-->

---

:gear: **Change Description**
This is so that GOAT doesn't wait indefinitely if there's a problem, ensuring a timely reaping of the task pod.

<!--
**Change Type**:
*Why this change? Reference the ticket and acceptance criteria if any. Specify the type of change: bug fix, new feature, breaking change, documentation update, security, etc.*
-->

**Acceptance Criteria**:

---

:white_check_mark: **Solution**

<!--
*What was the solution? How did you fix the issue or implement the new feature?*
-->

---

:question: **Testing**

<!--
*Describe what was tested. Remember to include changes in functionality, edge cases, and enough detail that another developer can replicate your progress.*
-->

- [x] Created and updated tests where applicable

---

:book: **Documentation Updates**

<!--
*Have any updates been made to the documentation?*
-->

- [ ] Updated related documentation, if applicable
- [x] Updated [changelog](https://github.com/circleci/runner-init/blob/main/CHANGELOG.md)
