### PR TITLE
[ONPREM-1972] Don't re-handle task errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ By following these guidelines, we can easily determine which changes should be i
 
 ## Edge
 
+- [#133](https://github.com/circleci/runner-init/pull/133) Don't re-handle task errors. If GOAT handles a task error (either with an infra-fail or retry), don't exit with a nonzero status code. Doing so causes container agent to overwrite the original error message in the UI.
 - [#98](https://github.com/circleci/runner-init/pull/98) [INTERNAL] A small refactor to the builds and Dockerfiles in preparation for adding Windows support.
 - [#97](https://github.com/circleci/runner-init/pull/97) Add timeout for the "wait-for-readiness" check on startup. This is so that GOAT doesn't wait indefinitely if there's a problem, ensuring a timely reaping of the task pod.
 - [#89](https://github.com/circleci/runner-init/pull/89) [INTERNAL] Add an option to wait for a readiness file, which is used via a shared volume to signal the readiness of all containers in the task pod.

--- a/cmd/orchestrator/main.go
+++ b/cmd/orchestrator/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/circleci/runner-init/cmd/setup"
 	initialize "github.com/circleci/runner-init/init"
 	"github.com/circleci/runner-init/task"
+	"github.com/circleci/runner-init/task/taskerrors"
 )
 
 type cli struct {
@@ -45,7 +46,9 @@ type runTaskCmd struct {
 
 func main() {
 	err := run(cmd.Version, cmd.Date)
-	if err != nil && !errors.Is(err, termination.ErrTerminated) {
+	if err != nil &&
+		!errors.Is(err, termination.ErrTerminated) &&
+		!errors.As(err, &taskerrors.HandledError{}) {
 		log.Fatal(err)
 	}
 }

--- a/task/taskerrors/taskerrors.go
+++ b/task/taskerrors/taskerrors.go
@@ -1,0 +1,25 @@
+package taskerrors
+
+import "fmt"
+
+type RetryableError struct {
+	error
+}
+
+func RetryableErrorf(format string, a ...any) RetryableError {
+	return RetryableError{fmt.Errorf(format, a...)}
+}
+
+// HandledError indicates the error has been managed (infra-fail or retry)
+// and shouldn't be handled further up the call stack.
+type HandledError struct {
+	err error
+}
+
+func (h HandledError) Error() string {
+	return fmt.Sprintf("handled: %v", h.err)
+}
+
+func NewHandledError(err error) HandledError {
+	return HandledError{err}
+}

--- a/task/taskerrors/taskerrors_test.go
+++ b/task/taskerrors/taskerrors_test.go
@@ -1,0 +1,25 @@
+package taskerrors
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"gotest.tools/v3/assert"
+	"gotest.tools/v3/assert/cmp"
+)
+
+func TestNewHandledError(t *testing.T) {
+	t.Run("Is a handled error", func(t *testing.T) {
+		err := NewHandledError(fmt.Errorf("something wrong happened"))
+
+		assert.Check(t, errors.As(err, &HandledError{}))
+		assert.Check(t, cmp.ErrorContains(err, "handled: something wrong happened"))
+	})
+
+	t.Run("Isn't a handled error", func(t *testing.T) {
+		err := fmt.Errorf("fatal")
+
+		assert.Check(t, !errors.As(err, &HandledError{}))
+	})
+}


### PR DESCRIPTION
Don't re-handle task errors. If GOAT handles a task error (either with an infra-fail or retry), don't exit with a nonzero status code. Doing so causes container agent to overwrite the original error message in the UI.

:gear: **Issue**

<!-- 
**Ticket/s**: 
-->

https://circleci.atlassian.net/browse/ONPREM-1972

---

:gear: **Change Description**

<!--
**Change Type**:
*Why this change? Reference the ticket and acceptance criteria if any. Specify the type of change: bug fix, new feature, breaking change, documentation update, security, etc.*
-->

**Acceptance Criteria**:

---

:white_check_mark: **Solution**

<!--
*What was the solution? How did you fix the issue or implement the new feature?*
-->

---

:question: **Testing**

Before: https://app.circleci.com/pipelines/github/circleci/runner-dummy/3032/workflows/2756dd1b-3af4-4305-b7d2-0effbd68b000/jobs/193765

After: https://app.circleci.com/pipelines/github/circleci/runner-dummy/3032/workflows/23a63cf9-4ee1-4a53-b6d3-c41d9ff7b5b6/jobs/193764

<!--
*Describe what was tested. Remember to include changes in functionality, edge cases, and enough detail that another developer can replicate your progress.*
-->

- [ ] Created and updated tests where applicable

---

:book: **Documentation Updates**

<!--
*Have any updates been made to the documentation?*
-->

- [ ] Updated related documentation, if applicable
- [ ] Updated [changelog](https://github.com/circleci/runner-init/blob/main/CHANGELOG.md)
