### PR TITLE
[SECENG-2259] Upgrade vuln-scanner orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ parameters:
 
 orbs:
   slack: circleci/slack@5.1.1
-  vuln-scanner: cci-internal/snyk-vuln-scanner@0.9.1
+  vuln-scanner: cci-internal/vuln-scanner@0.11.3
 
 executors:
   go:


### PR DESCRIPTION
We updated the old snyk-vuln-scanner to use Wiz. Right now we are running it without blocking/failing builds.
You can look inside the job details for scan results. The execution of this job should be running the same way as before.

If you were scanning a Docker image there are some small changes to do (refer to the [README](https://github.com/circleci/vuln-scanner-orb) for the details).

:gear: **Issue**

<!-- 
**Ticket/s**: 
-->

---

:gear: **Change Description**

<!--
**Change Type**:
*Why this change? Reference the ticket and acceptance criteria if any. Specify the type of change: bug fix, new feature, breaking change, documentation update, security, etc.*
-->

**Acceptance Criteria**:

---

:white_check_mark: **Solution**

<!--
*What was the solution? How did you fix the issue or implement the new feature?*
-->

---

:question: **Testing**

<!--
*Describe what was tested. Remember to include changes in functionality, edge cases, and enough detail that another developer can replicate your progress.*
-->

- [ ] Created and updated tests where applicable

---

:book: **Documentation Updates**

<!--
*Have any updates been made to the documentation?*
-->

- [ ] Updated related documentation, if applicable
- [ ] Updated [changelog](https://github.com/circleci/runner-init/blob/main/CHANGELOG.md)
