### PR TITLE
Only look at the base path in readiness check

### DIFF
--- a/task/orchestrator.go
+++ b/task/orchestrator.go
@@ -144,7 +144,7 @@ func (o *Orchestrator) waitForReadiness(ctx context.Context) (err error) {
 	for {
 		select {
 		case event, ok := <-watcher.Events:
-			if ok && event.Has(fsnotify.Create) && event.Name == readinessFilePath {
+			if ok && event.Has(fsnotify.Create) && filepath.Base(event.Name) == filepath.Base(readinessFilePath) {
 				return nil
 			}
 		case err, ok := <-watcher.Errors:

--- a/task/orchestrator_test.go
+++ b/task/orchestrator_test.go
@@ -319,7 +319,8 @@ func TestOrchestrator_waitForReadiness(t *testing.T) {
 		defer cancel()
 
 		o := Orchestrator{}
-		o.config.ReadinessFilePath = filepath.Join(t.TempDir(), "ready")
+		// Test a slash-separated path to ensure the readiness check handles it across different platforms
+		o.config.ReadinessFilePath = filepath.ToSlash(filepath.Join(t.TempDir(), "ready"))
 
 		go func() {
 			time.Sleep(250 * time.Millisecond)


### PR DESCRIPTION
This is to ensure the readiness check for service containers, which depends on a file notification, works on Windows. We were comparing the event name with the path, but this path wasn't localized, so the match would fail on Windows. Instead, we can just look at the base of the path since we only set up the watcher on the containing directory.

:gear: **Issue**

<!-- 
**Ticket/s**: 
-->

---

:gear: **Change Description**

<!--
**Change Type**:
*Why this change? Reference the ticket and acceptance criteria if any. Specify the type of change: bug fix, new feature, breaking change, documentation update, security, etc.*
-->

**Acceptance Criteria**:

---

:white_check_mark: **Solution**

<!--
*What was the solution? How did you fix the issue or implement the new feature?*
-->

---

:question: **Testing**

<!--
*Describe what was tested. Remember to include changes in functionality, edge cases, and enough detail that another developer can replicate your progress.*
-->

- [ ] Created and updated tests where applicable

---

:book: **Documentation Updates**

<!--
*Have any updates been made to the documentation?*
-->

- [ ] Updated related documentation, if applicable
- [ ] Updated [changelog](https://github.com/circleci/runner-init/blob/main/CHANGELOG.md)
