### PR TITLE
Use looser task event timestamp comparer

### DIFF
--- a/internal/testing/fakerunnerapi/fakerunnerapi.go
+++ b/internal/testing/fakerunnerapi/fakerunnerapi.go
@@ -40,7 +40,7 @@ type TaskEvent struct {
 }
 
 var CmpTaskEvent = gocmp.Options{
-	cmpopts.EquateApproxTime(time.Second * 20),
+	cmpopts.EquateApproxTime(1 * time.Minute),
 	cmpopts.AcyclicTransformer("TimestampMilli", func(msec int64) time.Time {
 		return time.UnixMilli(msec)
 	}),


### PR DESCRIPTION
The tests are little slower on Windows, so let's make this check more tolerant

https://app.circleci.com/pipelines/github/circleci/runner-init/9731/workflows/8f51e125-f830-4183-8b3a-b3ea6a0d56d4/jobs/16417?invite=true#step-106-35891_88

:gear: **Issue**

<!-- 
**Ticket/s**: 
-->

---

:gear: **Change Description**

<!--
**Change Type**:
*Why this change? Reference the ticket and acceptance criteria if any. Specify the type of change: bug fix, new feature, breaking change, documentation update, security, etc.*
-->

**Acceptance Criteria**:

---

:white_check_mark: **Solution**

<!--
*What was the solution? How did you fix the issue or implement the new feature?*
-->

---

:question: **Testing**

<!--
*Describe what was tested. Remember to include changes in functionality, edge cases, and enough detail that another developer can replicate your progress.*
-->

- [ ] Created and updated tests where applicable

---

:book: **Documentation Updates**

<!--
*Have any updates been made to the documentation?*
-->

- [ ] Updated related documentation, if applicable
- [ ] Updated [changelog](https://github.com/circleci/runner-init/blob/main/CHANGELOG.md)
