### PR TITLE
[ONPREM-2536] Fix child process cleanup on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ By following these guidelines, we can easily determine which changes should be i
 
 ## Edge
 
+- [#212](https://github.com/circleci/runner-init/pull/212) Fix child process cleanup on Windows using job objects. This ensures that child processes are destroyed when the parent process (task-agent) terminates.
 - [#197](https://github.com/circleci/runner-init/pull/197) Fix `%PATH%` on Windows by using the OS-specific path list separator.
 - [#133](https://github.com/circleci/runner-init/pull/133) Don't re-handle task errors. If GOAT handles a task error (either with an infra-fail or retry), don't exit with a nonzero status code. Doing so causes container agent to overwrite the original error message in the UI.
 - [#98](https://github.com/circleci/runner-init/pull/98) [INTERNAL] A small refactor to the builds and Dockerfiles in preparation for adding Windows support.

--- a/go.mod
+++ b/go.mod
@@ -623,7 +623,7 @@ require (
 	go.opentelemetry.io/proto/otlp v1.7.1 // indirect
 	golang.org/x/net v0.43.0 // indirect
 	golang.org/x/sync v0.16.0 // indirect
-	golang.org/x/sys v0.35.0 // indirect
+	golang.org/x/sys v0.35.0
 	golang.org/x/text v0.28.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250728155136-f173205681a0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250728155136-f173205681a0 // indirect

--- a/task/cmd/cmd.go
+++ b/task/cmd/cmd.go
@@ -33,7 +33,7 @@ func New(ctx context.Context, cmd []string, forwardSignals bool, user string, en
 func (c *Command) Start() error {
 	cmd := c.cmd
 
-	if err := cmd.Start(); err != nil {
+	if err := c.start(); err != nil {
 		return err
 	}
 

--- a/task/cmd/cmd_unix.go
+++ b/task/cmd/cmd_unix.go
@@ -49,3 +49,7 @@ func additionalSetup(_ context.Context, cmd *exec.Cmd) {
 		return syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
 	}
 }
+
+func (c *Command) start() error {
+	return c.cmd.Start()
+}

--- a/task/cmd/cmd_windows.go
+++ b/task/cmd/cmd_windows.go
@@ -5,8 +5,12 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"sync"
+	"sync/atomic"
+	"unsafe"
 
 	"github.com/circleci/ex/o11y"
+	"golang.org/x/sys/windows"
 )
 
 func forwardSignals(cmd *exec.Cmd) {
@@ -14,6 +18,7 @@ func forwardSignals(cmd *exec.Cmd) {
 	signal.Notify(ch, os.Interrupt)
 
 	go func() {
+		defer signal.Stop(ch)
 		for range ch {
 			_ = cmd.Process.Kill()
 		}
@@ -24,4 +29,67 @@ func switchUser(ctx context.Context, _ *exec.Cmd, user string) {
 	o11y.Log(ctx, "switching users is unsupported on windows", o11y.Field("username", user))
 }
 
-func additionalSetup(_ context.Context, _ *exec.Cmd) {}
+func additionalSetup(_ context.Context, cmd *exec.Cmd) {
+	cmd.SysProcAttr.CreationFlags = windows.CREATE_NEW_PROCESS_GROUP
+}
+
+func (c *Command) start() error {
+	g, err := newProcessExitGroup()
+	if err != nil {
+		return err
+	}
+
+	c.cmd.Cancel = func() error {
+		return g.Dispose()
+	}
+
+	if err := c.cmd.Start(); err != nil {
+		return err
+	}
+
+	return g.AddProcess(c.cmd.Process)
+}
+
+// Process struct matches os.Process layout to extract handle via unsafe pointer
+// https://stackoverflow.com/a/56739249
+type process struct {
+	Pid    int
+	_      uint8
+	_      atomic.Uint64
+	_      sync.RWMutex
+	Handle uintptr
+}
+
+type processExitGroup windows.Handle
+
+func newProcessExitGroup() (processExitGroup, error) {
+	handle, err := windows.CreateJobObject(nil, nil)
+	if err != nil {
+		return 0, err
+	}
+
+	info := windows.JOBOBJECT_EXTENDED_LIMIT_INFORMATION{
+		BasicLimitInformation: windows.JOBOBJECT_BASIC_LIMIT_INFORMATION{
+			LimitFlags: windows.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+		},
+	}
+	if _, err := windows.SetInformationJobObject(
+		handle,
+		windows.JobObjectExtendedLimitInformation,
+		uintptr(unsafe.Pointer(&info)),
+		uint32(unsafe.Sizeof(info))); err != nil {
+		return 0, err
+	}
+
+	return processExitGroup(handle), nil
+}
+
+func (g processExitGroup) Dispose() error {
+	return windows.CloseHandle(windows.Handle(g))
+}
+
+func (g processExitGroup) AddProcess(p *os.Process) error {
+	return windows.AssignProcessToJobObject(
+		windows.Handle(g),
+		windows.Handle((*process)(unsafe.Pointer(p)).Handle))
+}


### PR DESCRIPTION
:gear: **Issue**

<!-- 
**Ticket/s**: 
-->

https://circleci.atlassian.net/browse/ONPREM-2536

---

:gear: **Change Description**

There was a bug on Windows in the test to check for lingering child processes after task agent terminates. Once this test was fixed, it was revealed that child processes weren't getting destroyed as expected. This updates the `cmd` package to set up a job object for the task agent prcoess and its children so that they will destroyed accordingly.

<!--
**Change Type**:
*Why this change? Reference the ticket and acceptance criteria if any. Specify the type of change: bug fix, new feature, breaking change, documentation update, security, etc.*
-->

**Acceptance Criteria**:

---

:white_check_mark: **Solution**

<!--
*What was the solution? How did you fix the issue or implement the new feature?*
-->

---

:question: **Testing**

<!--
*Describe what was tested. Remember to include changes in functionality, edge cases, and enough detail that another developer can replicate your progress.*
-->

- [ ] Created and updated tests where applicable

---

:book: **Documentation Updates**

<!--
*Have any updates been made to the documentation?*
-->

- [ ] Updated related documentation, if applicable
- [ ] Updated [changelog](https://github.com/circleci/runner-init/blob/main/CHANGELOG.md)
