### PR TITLE
Build runner-init image for 4.10

### DIFF
--- a/do
+++ b/do
@@ -51,7 +51,7 @@ images() {
 # shellcheck disable=SC2034
 help_images_for_server="Build and push the Docker images and manifests for supported server versions."
 images-for-server() {
-    versions_array=(4.8 4.9 4.10 5.0)
+    versions_array=(4.8 4.9 4.10)
     last_version="${versions_array[-1]}"
 
     for version in "${versions_array[@]}"; do

--- a/do
+++ b/do
@@ -51,7 +51,7 @@ images() {
 # shellcheck disable=SC2034
 help_images_for_server="Build and push the Docker images and manifests for supported server versions."
 images-for-server() {
-    versions_array=(4.8 4.9 5.0)
+    versions_array=(4.8 4.9 4.10 5.0)
     last_version="${versions_array[-1]}"
 
     for version in "${versions_array[@]}"; do


### PR DESCRIPTION
:gear: **Issue**

<!-- 
**Ticket/s**: 
-->

---

:gear: **Change Description**
We need to build the `runner-init` image for 4.10 as `cci-synthetics` is failing to pull the image that doens't exist.

<!--
**Change Type**:
*Why this change? Reference the ticket and acceptance criteria if any. Specify the type of change: bug fix, new feature, breaking change, documentation update, security, etc.*
-->

**Acceptance Criteria**:

---

:white_check_mark: **Solution**

<!--
*What was the solution? How did you fix the issue or implement the new feature?*
-->

---

:question: **Testing**

<!--
*Describe what was tested. Remember to include changes in functionality, edge cases, and enough detail that another developer can replicate your progress.*
-->

- [ ] Created and updated tests where applicable

---

:book: **Documentation Updates**

<!--
*Have any updates been made to the documentation?*
-->

- [ ] Updated related documentation, if applicable
- [ ] Updated [changelog](https://github.com/circleci/runner-init/blob/main/CHANGELOG.md)
