### PR TITLE
DELENG-458 Update to vuln-scanner-orb 0.11.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ parameters:
 
 orbs:
   slack: circleci/slack@6.1.2
-  vuln-scanner: cci-internal/vuln-scanner@0.11.7
+  vuln-scanner: cci-internal/vuln-scanner@0.11.8
 
 x-data:
   go_image: &goimage cimg/go:1.26.1


### PR DESCRIPTION
Jira - https://circleci.atlassian.net/browse/DELENG-458

Update to the [latest version of the vuln-scanner-orb](https://github.com/circleci/vuln-scanner-orb/releases). Versions prior to `0.11.8` use credentials that are scheduled for deletion in the security-scanning context. So, they are deprecated. Updating to this version will avoid auth failures for the Wiz CLI during vuln scans.