### PR TITLE
[OPM-315] Enable automerge for Renovate security/CVE PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,12 +65,19 @@ workflows:
           upload_on_merge: true
       - check-license-attributions:
           context: [ org-global ]
-      - images:
-          context: [ org-global, runner-image-signing ] 
+      - images: &images_job
+          name: images-dev
+          context: [ org-global ]
           requires: [ lint, build, scan, vuln-scanner/vuln_scan ]
+          filters: { branches: { ignore: main } }
+      - images:
+          <<: *images_job
+          name: images-main
+          context: [ org-global, runner-image-signing ]
+          filters: { branches: { only: main } }
       - smoke-tests:
           context: [ org-global, runner-smoke-tests ]
-          requires: [ images ]
+          requires: [ images-dev, images-main ]
   nightly:
     when:
       or:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,7 +154,9 @@ jobs:
       - setup
       - with-go-cache:
           steps:
-            - run: ./do test ./...
+            - run:
+                command: ./do test ./...
+                max_auto_reruns: 2
       - store_results
       - notify_failing_main
 

--- a/do
+++ b/do
@@ -36,6 +36,9 @@ images() {
     skip="${SKIP_PUSH:-true}"
     [ "${SKIP_PUSH:-true}" = "true" ] && push_windows="false" || push_windows="true"
 
+    skip_steps="validate"
+    [ -z "${COSIGN_PWD:-}" ] && skip_steps="${skip_steps},sign"
+
     SKIP_PUSH="${skip}" \
         SKIP_PUSH_TEST_AGENT="${SKIP_PUSH_TEST_AGENT:-${skip}}" \
         PUSH_WINDOWS="${push_windows}" \
@@ -44,7 +47,7 @@ images() {
         go tool goreleaser \
         --clean \
         --config "${BUILD_CONFIG:-./.goreleaser/dockers.yaml}" \
-        --skip=validate "$@"
+        --skip="${skip_steps}" "$@"
 }
 
 # This variable is used, but shellcheck can't tell.

--- a/renovate.json
+++ b/renovate.json
@@ -51,6 +51,17 @@
         "github.com/circleci/ex"
       ],
       "ignoreUnstable": false
+    },
+    {
+      "description": "Automerge CVE/Security updates",
+      "matchJsonata": ["$exists(isVulnerabilityAlert) and isVulnerabilityAlert = true"],
+      "automerge": true,
+      "automergeSchedule": [
+        "* 8-17 * * 1-5"
+      ],
+      "labels": [
+        "AUTOMERGE", "CVE", "security"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Main change is enabling Renovate automerge for security/CVE PRs.
The other two changes facilitate this by making the dev pipeline
viable for unattended Renovate runs:

- Gate the restricted runner-image-signing context to main so
  Renovate branches can run the full e2e images/smoke-tests
- Auto-rerun tests up to 2x to absorb Windows flakiness that
  would otherwise block automerge