### PR TITLE
[backplane/repo-fixer] configure Cloudsmith as Go module registry

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,7 @@ parameters:
 orbs:
   slack: circleci/slack@6.1.3
   vuln-scanner: cci-internal/vuln-scanner@0.11.8
+  cloudsmith: https://raw.githubusercontent.com/circleci/backplane-cicd/main/orbs/cloudsmith.yml
 
 x-data:
   go_image: &goimage cimg/go:1.26.4
@@ -245,6 +246,8 @@ jobs:
     executor: go-medium
     steps:
       - checkout
+      - cloudsmith/configure:
+          go: true
       - with-go-cache:
           steps:
             - run: ./do license-attributions
@@ -311,6 +314,8 @@ jobs:
     executor: go
     steps:
       - checkout
+      - cloudsmith/configure:
+          go: true
       - attach_workspace:
           at: /tmp/workspace
       - with-go-cache:
@@ -329,6 +334,8 @@ commands:
   setup:
     steps:
       - checkout
+      - cloudsmith/configure:
+          go: true
       - attach_workspace:
           at: .
       - run: go mod download
@@ -452,8 +459,8 @@ commands:
           steps:
             - restore_cache:
                 keys:
-                  - v1-go-mod-{{ checksum "go.sum" }}
-                  - v1-go-mod-
+                  - v2-go-mod-{{ checksum "go.sum" }}
+                  - v2-go-mod-
       - when:
           condition: << parameters.golangci-lint >>
           steps:
@@ -471,7 +478,7 @@ commands:
           condition: << parameters.go-mod >>
           steps:
             - save_cache:
-                key: v1-go-mod-{{ checksum "go.sum" }}
+                key: v2-go-mod-{{ checksum "go.sum" }}
                 paths:
                   - /home/circleci/go/pkg/mod
       - when:


### PR DESCRIPTION
> [!IMPORTANT]
> <sub>This PR was AI-generated by the [backplane-cicd repo-fixer pipeline](https://github.com/circleci/backplane-cicd/blob/main/pipelines/repo-fixer.yml). Give feedback in [#backplane-ecosystem](https://circleci.slack.com/archives/C06BR4CLXAT).</sub>

configure Cloudsmith as Go module registry

migrate Go module downloads to the circleci-deps Cloudsmith org for improved reliability and security

see: https://circleci.atlassian.net/wiki/spaces/DELENG/pages/8607006756/Cloudsmith+FAQ

questions? reach out in #cloudsmith-rollout