### PR TITLE
[backplane/repo-fixer] upgrade machine resource classes to gen3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,8 +40,8 @@ executors:
     resource_class: medium.gen2
   linux_machine:
     machine:
-      image: ubuntu-2204:2024.02.7
-      resource_class: large
+      image: ubuntu-2204:current
+      resource_class: large.gen3
 
 workflows:
   main-workflow:


### PR DESCRIPTION
> [!IMPORTANT]
> <sub>This PR was AI-generated by the [backplane-cicd repo-fixer pipeline](https://github.com/circleci/backplane-cicd/blob/main/pipelines/repo-fixer.yml). Give feedback in [#backplane-ecosystem](https://circleci.slack.com/archives/C06BR4CLXAT).</sub>

upgrade machine resource classes to gen3

Append .gen3 to machine executor resource_class values (medium, large, xlarge, 2xlarge, 2xlarge+).

Gen3 only supports the current and edge image tags, so pinned/dated tags
(e.g. ubuntu-2404:2024.11.1) are rewritten to ubuntu-2404:current.

Jobs with circleci_ip_ranges are left unchanged (incompatible).

Jobs without an explicit resource_class get medium.gen3 (the default was medium).

See: https://circleci.com/docs/reference/configuration-reference/#linuxvm-gen3-execution-environment
Fixer-Version: 1